### PR TITLE
Xprof flavoured match-spec funs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,6 @@ webpack:
 	cd priv; webpack
 
 test: compile
-	./rebar3 ct -c
+	./rebar3 do eunit -c, ct -c, cover
 
 .PHONY=compile dev bower webpack test

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ that lasted longer than given number of milliseconds.
 
 XProf was created to help solving performance problems of live, highly
 concurrent and utilized BE systems. It's often the case that high latency or big
-CPU usage driven by is caused by very specific requests that are triggering
+CPU usage is caused by very specific requests that are triggering
 inefficient code. Finding this code is usually pretty difficult.
 
 ## How to use it
@@ -38,6 +38,32 @@ Key         | Default     | Description
 :-----------|:------------|:-----------
 port        |7890         |Port for the web interface
 
+## Xprof flavoured match-spec funs
+
+In the function browser you can also specify further filters in the form of a
+match-spec fun (similar to recon or redbug). After the module and function name
+one can also give a function definition instead of arity. This gives the user
+the full power of match specifications and can be used both to selectively
+measure duration of function calls that match complicated filters and to capture
+only part of the arguments. The function has the same limitations as
+`dbg:fun2ms/1`. (See
+[Match Specifications in Erlang](http://erlang.org/doc/apps/erts/match_spec.html) and
+[ms\_transform](http://erlang.org/doc/man/ms_transform.html)). The function can
+be terminated by a single dot or `end.` and `return_trace` is always implicitly
+on (that is how xprof measures duration)
+
+For example only measure the duration of `ets:lookup` on table `data`
+
+```erlang
+ets:lookup([data, _]) -> true.
+```
+
+Or only capture the `important` field of a possibly big `data` record
+
+```erlang
+ets:insert([_, #data{important = I}]) -> message(I).
+```
+
 ## Contributing
 
 All improvements, fixes and ideas are very welcomed!
@@ -48,8 +74,8 @@ build JS sources in order to run xprof.
 
 ### Running tests
 
-```erlang
-./rebar3 ct
+```bash
+make test
 ```
 
 ### Working with JS sources
@@ -74,7 +100,7 @@ reloads modules that have changed.
 
 ```bash
 $ export REBAR_PROFILE=dev
-$ ./rebar shell
+$ ./rebar3 shell
 > sync:go().
 > xprof:start().
 ```

--- a/priv/app/function_browser.jsx
+++ b/priv/app/function_browser.jsx
@@ -126,7 +126,7 @@ export default class FunctionBrowser extends React.Component {
         this.clear();
         break;
       case 13: /* RETURN */
-        /* submit funciton or try to compelete using selected fun */
+        /* submit function or try to complete using selected fun */
         e.preventDefault();
 
         enteredFun = this.matchFunSignature(e.target.value);
@@ -140,7 +140,7 @@ export default class FunctionBrowser extends React.Component {
         e.preventDefault();
         this.completeSearch();
         break;
-      case 38: /* ARROw UP */
+      case 38: /* ARROW UP */
         /* select next fun from the list */
         this.refs.acm.moveHighlight(-1);
         break;

--- a/priv/app/graph.jsx
+++ b/priv/app/graph.jsx
@@ -134,6 +134,9 @@ export default class Graph extends React.Component {
   }
 
   chartId() {
-    return `chart_${this.props.fun[0]}_${this.props.fun[1]}_${this.props.fun[2]}`
+    var arity = this.props.fun[2];
+    // '*' is not a valid character in a tag id
+    if(arity == '*') arity = 'x';
+    return `chart_${this.props.fun[0]}_${this.props.fun[1]}_${arity}`
   }
 }

--- a/priv/build/bundle.js
+++ b/priv/build/bundle.js
@@ -1369,7 +1369,10 @@ webpackJsonp([0],[
 	  }, {
 	    key: 'chartId',
 	    value: function chartId() {
-	      return 'chart_' + this.props.fun[0] + '_' + this.props.fun[1] + '_' + this.props.fun[2];
+          var arity = this.props.fun[2];
+          // '*' is not a valid character in a tag id
+          if(arity == '*') arity = 'x';
+	      return 'chart_' + this.props.fun[0] + '_' + this.props.fun[1] + '_' + arity;
 	    }
 	  }]);
 

--- a/src/xprof.erl
+++ b/src/xprof.erl
@@ -5,6 +5,23 @@
 
 -include("xprof.hrl").
 
+%% match-spec
+-type ms() :: [tuple()].
+%% traced function with optional match-spec
+%% used to initiate tracing (both by xprof_tracer and xprof_tracer_handler)
+-type mfaspec() :: mfa() | {module(), atom(), {ms(), ms()}}.
+
+%% used by gui and xprof_tracer to identify mfas
+%% arity of '*' means all arities
+-type mfaid() :: {module(), atom(), arity() | '*'}.
+
+%% derived from mfaid
+%% used to register ets tables and xprof_tracer_handler gen_servers
+-type mfaname() :: atom().
+
+-export_type([mfaspec/0, mfaid/0, mfaname/0]).
+
+
 start() ->
     application:ensure_all_started(?APP).
 

--- a/src/xprof_lib.erl
+++ b/src/xprof_lib.erl
@@ -1,10 +1,26 @@
 -module(xprof_lib).
 
--export([mfa2atom/1, now2epoch/1]).
+-export([mfa2atom/1, mfaspec2id/1, now2epoch/1]).
 
+-spec mfa2atom(xprof_tracer:mfaspec() | xprof_tracer:mfaid()) ->
+                      xprof_tracer:mfaname().
+mfa2atom({M, F, {_MSOff, _MSOn}}) ->
+    mfa2atom({M, F, '*'});
+mfa2atom({M, F, '*'}) ->
+    list_to_atom(string:join(["xprof_", atom_to_list(M),
+                              atom_to_list(F), "*"], "_"));
 mfa2atom({M,F,A}) ->
     list_to_atom(string:join(["xprof_", atom_to_list(M),
                               atom_to_list(F), integer_to_list(A)], "_")).
+
+
+-spec mfaspec2id(xprof:mfaspec()) -> xprof:mfaid().
+mfaspec2id({M, F, {_, _}})
+  when is_atom(M), is_atom(F) ->
+    {M, F, '*'};
+mfaspec2id({M, F, A} = MFA)
+  when is_atom(M), is_atom(F), is_integer(A) ->
+    MFA.
 
 now2epoch({MS, S, _US}) ->
     MS * 1000000 + S.

--- a/src/xprof_ms.erl
+++ b/src/xprof_ms.erl
@@ -1,0 +1,124 @@
+-module(xprof_ms).
+
+-compile(export_all).
+
+fun2ms(Str) ->
+    try
+        case tokens(Str) of
+            {mfa, _M, _F, _Arity} = MFA ->
+                MFA;
+            {clauses, M, F, Tokens} ->
+                Clauses = parse(Tokens),
+                MS = ms(Clauses),
+                {ms, M, F, fix_ms(MS)}
+        end
+    catch throw:Error ->
+            Error
+    end.
+
+tokens(Str) ->
+    case erl_scan:string(Str, {1,1}) of
+        {error, {_Loc, Mod, Err}, Loc} ->
+            err(Loc, Mod, Err);
+        {ok, [{atom, _, M}, {':', _},
+              {atom, _, F}, {'/', _},
+              {integer, _, A}], _EndLoc} ->
+            {mfa, M, F, A};
+        {ok, [{atom, _, M}, {':', _},
+              {atom, _, F}|Tokens], _EndLoc} when Tokens =/= [] ->
+            {clauses, M, F, [{'fun', 0}|ensure_end(Tokens)]};
+        {ok, Tokens, _EndLoc} ->
+            err("expression is not an xprof match-spec fun ~w", [Tokens])
+    end.
+
+%% @doc Ensure the fun is properly closed with "end."
+ensure_end(Tokens) ->
+    case lists:reverse(Tokens) of
+        [{dot, _}, {'end', _}| _] -> Tokens;
+        [{dot, Loc}|T] -> lists:reverse(T, [{'end', Loc}, {dot, Loc}]);
+        [Last|_] = R ->
+            Loc = element(2, Last),
+            lists:reverse(R, [{'end', Loc}, {dot, Loc}])
+    end.
+
+parse(Tokens) ->
+    case erl_parse:parse_exprs(Tokens) of
+        {error, {Loc, Mod, Err}} ->
+            err(Loc, Mod, Err);
+        {ok, [{'fun', _Loc, {clauses, Clauses}}]} ->
+            Clauses;
+        {ok, _} ->
+            err("expression is not an xprof match-spec fun")
+    end.
+
+ms(Clauses) ->
+    case ms_transform:transform_from_shell(
+           dbg, Clauses, _ImportList = []) of
+        {error,[{_,[{Loc,Mod,Code}|_]}|_],_} ->
+            err(Loc, Mod, Code);
+        MS ->
+            MS
+    end.
+
+%% @doc Ensure that the match-spec does not create traces that have different
+%% format than what xprof_trace_handler anticipates (ie. {message, _} directives
+%% might have to be modified)
+
+%% - The special case {message, false} is allowed (disables sending of trace
+%% messages ('call' and 'return_to') for this function call, just like if the
+%% match specification had not matched).
+
+%% - The special case {message, true} must be avoided (sets the default
+%% behavior, ie. trace message is sent with no extra information). These calls
+%% are replaced with our default message ({message, arity} or {message, '$_'})
+
+%% - Other values for messages are allowed but later overriden by placing
+%% {message, arity} at the end of the match-spec body in case argument capturing
+%% is off
+
+%% - For the general case when the match-spec body does not contain any message
+%% directive a default message ({message, arity} or {message, '$_'}) is inserted
+%% as the first action of the body as well as enabling return_trace
+
+fix_ms(MS) ->
+    {traverse_ms(MS, _CaptureOff = false),
+     traverse_ms(MS, _CaptureOn = true)}.
+
+traverse_ms(MS, Capture) ->
+    DefaultMsg =
+        case Capture of
+            false -> arity;
+            true -> '$_'
+        end,
+    [{Head, Condition,
+      [{return_trace},{message, DefaultMsg}|traverse_ms_c(Body, Capture)]}
+     || {Head, Condition, Body} <- MS].
+
+%% @doc traverse a match-spec clause
+traverse_ms_c([{message, true}|T], false) ->
+    [{message, arity}|traverse_ms_c(T, false)];
+traverse_ms_c([{message, true}|T], true) ->
+    [{message, '$_'}|traverse_ms_c(T, true)];
+traverse_ms_c([{message, Other}|T], false) when Other =/= false ->
+    [{message, arity}|traverse_ms_c(T, false)];
+traverse_ms_c([H|T], C) ->
+    [traverse_ms_c(H, C)|traverse_ms_c(T, C)];
+traverse_ms_c(Tuple, C) when is_tuple(Tuple) ->
+    list_to_tuple(traverse_ms_c(tuple_to_list(Tuple), C));
+traverse_ms_c([], _) ->
+    [];
+traverse_ms_c(Other, _) ->
+    Other.
+
+
+err(Fmt) ->
+    throw({error, fmt(Fmt, [])}).
+
+err(Fmt, Args) ->
+    throw({error, fmt(Fmt, Args)}).
+
+err({1, Col}, Mod, Err) ->
+    throw({error, fmt("~s at column ~p", [Mod:format_error(Err), Col])}).
+
+fmt(Fmt, Args) ->
+    lists:flatten(io_lib:format(Fmt, Args)).

--- a/test/xprof_ms_tests.erl
+++ b/test/xprof_ms_tests.erl
@@ -1,0 +1,81 @@
+-module(xprof_ms_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, xprof_ms).
+
+tokens_test_() ->
+    [?_assertEqual(
+        {error,"expression is not an xprof match-spec fun []"},
+        ?M:fun2ms("")),
+     ?_assertEqual(
+        {error,"unterminated atom starting with 'true' at column 16"},
+        ?M:fun2ms("m:f(_) -> 'true")),
+     ?_assertMatch(
+        {error,"expression is not an xprof match-spec fun" ++ _},
+        ?M:fun2ms("a+b"))
+    ].
+
+parse_test_() ->
+    [?_assertEqual(
+        {mfa, m, f, 1},
+        ?M:fun2ms("m:f/1")),
+     ?_assertEqual(
+        {error,"syntax error before: 'end' at column 4"},
+        ?M:fun2ms("m:f(")),
+     ?_assertEqual(
+        {error,"expression is not an xprof match-spec fun"},
+        ?M:fun2ms("m:f f/1, begin true"))
+    ].
+
+ensure_dor_test_() ->
+    MSs = {[{'_',[],[{return_trace},{message,arity},true]}],
+           [{'_',[],[{return_trace},{message,'$_'},true]}]},
+    [?_assertEqual(
+        {ms, m, f, MSs},
+        ?M:fun2ms("m:f(_) -> true")),
+     ?_assertEqual(
+        {ms, m, f, MSs},
+        ?M:fun2ms("m:f(_) -> true.")),
+     ?_assertEqual(
+        {ms, m, f, MSs},
+        ?M:fun2ms("m:f(_) -> true end."))
+    ].
+
+ms_test_() ->
+    [?_assertEqual(
+        {error,
+         "dbg:fun2ms requires fun with single variable "
+         "or list parameter at column 4"},
+        ?M:fun2ms("m:f(A, B) -> {A, B}")),
+    ?_assertEqual(
+       {error,
+        "in fun head, only matching (=) on toplevel can be translated "
+        "into match_spec at column 8"},
+        ?M:fun2ms("m:f([A = {B, _}]) -> {A, B}"))
+    ].
+
+traverse_ms_test_() ->
+
+    MSs =
+    {%% capture args off
+      [%% false -> false: no trace
+       {[a,'_'], [], [{return_trace},{message,arity},{message,false}]},
+       %% true -> arity: trace without args
+       {[b,'_'], [], [{return_trace},{message,arity},{message,arity}]},
+       %% custom msg -> arity: trace without args
+       {['_','$1'], [], [{return_trace},{message,arity},{message,arity}]}],
+      %% capture args on
+      [%% false -> false: no trace
+       {[a,'_'], [], [{return_trace},{message,'$_'},{message,false}]},
+       %% true -> '$_' aka object(): trace with all args
+       {[b,'_'], [], [{return_trace},{message,'$_'},{message,'$_'}]},
+       %% custom msg -> custom msg: trace with one arg only
+       {['_','$1'], [], [{return_trace},{message,'$_'},{message,'$1'}]}]},
+
+    [?_assertEqual(
+        {ms, m, f, MSs},
+        ?M:fun2ms("m:f([a, _]) -> message(false);"
+                  "   ([b, _]) -> message(true);"
+                  "   ([_, C]) -> message(C) end."))
+    ].


### PR DESCRIPTION
Extend query to allow special match-spec fun definitions. This will
allow both selectively measuring duration of function calls that match
complicated filters and capturing only part of the arguments.

WIP: right now the GUI has not been updated so initiating a function
monitoring is only supported from command line like:

``` erlang
xporf_tracer:monitor("ets:lookup([data, _]) -> true.").
```
