### PR TITLE
FIX: handle capture_data calls after tracing is stopped

### DIFF
--- a/src/xprof_tracer_handler.erl
+++ b/src/xprof_tracer_handler.erl
@@ -69,16 +69,20 @@ capture(MFA = {M,F,A}, Threshold, Limit) ->
                                         list(any())}.
 get_captured_data(MFA, Offset) ->
     Name = xprof_lib:mfa2atom(MFA),
-    Items = lists:sort(ets:select(Name,
-                                  [{
-                                     {{args_res, '$1'},
-                                      {'$2', '$3','$4','$5'}},
-                                     [{'>','$1',Offset}],
-                                     [['$1', '$2', '$3', '$4', '$5']]
-                                   }])),
+    try
+        Items = lists:sort(ets:select(Name,
+                                      [{
+                                         {{args_res, '$1'},
+                                          {'$2', '$3','$4','$5'}},
+                                         [{'>','$1',Offset}],
+                                         [['$1', '$2', '$3', '$4', '$5']]
+                                       }])),
 
-    [{capture_spec, Id, Threshold, Limit}] = ets:lookup(Name, capture_spec),
-    {ok, {Id, Threshold, Limit}, Items}.
+        [{capture_spec, Id, Threshold, Limit}] = ets:lookup(Name, capture_spec),
+        {ok, {Id, Threshold, Limit}, Items}
+    catch error:badarg ->
+            {error, not_found}
+    end.
 
 
 %% gen_server callbacks

--- a/src/xprof_web_handler.erl
+++ b/src/xprof_web_handler.erl
@@ -125,19 +125,21 @@ handle_req(<<"capture_data">>, Req, State) ->
     {OffsetStr, _} = cowboy_req:qs_val(<<"offset">>, Req),
     Offset = binary_to_integer(OffsetStr),
 
-
-    {ok, {Id, Threshold, Limit}, Items} =
-        xprof_tracer_handler:get_captured_data(MFA, Offset),
-
-    ItemsJson = [{args_res2proplist(Item)} || Item <- Items],
-    Json = jiffy:encode({[{capture_id, Id},
-                          {threshold, Threshold},
-                          {limit, Limit},
-                          {items, ItemsJson}]}),
-    {ok, ResReq} = cowboy_req:reply(200,
-                                    [{<<"content-type">>,
-                                      <<"application/json">>}],
-                                    Json, Req),
+    {ok, ResReq} =
+        case xprof_tracer_handler:get_captured_data(MFA, Offset) of
+            {error, not_found} ->
+                cowboy_req:reply(404, Req);
+            {ok, {Id, Threshold, Limit}, Items} ->
+                ItemsJson = [{args_res2proplist(Item)} || Item <- Items],
+                Json = jiffy:encode({[{capture_id, Id},
+                                      {threshold, Threshold},
+                                      {limit, Limit},
+                                      {items, ItemsJson}]}),
+                cowboy_req:reply(200,
+                                 [{<<"content-type">>,
+                                   <<"application/json">>}],
+                                 Json, Req)
+        end,
     {ok, ResReq, State}.
 
 %% Helpers


### PR DESCRIPTION
Just like in case of 'data' calls return 404