### PR TITLE
do cover report only for one OTP version, test with otp 19.2 too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,12 @@ branches:
     only:
         - master
 otp_release:
-    - 18.0
+    - 19.2
+    - 18.3
     - 17.5
     - R16B03-1
 script:
     make test
 after_success:
     - ./rebar3 cover
-    - erl -noshell -pa _build/test/lib/*/ebin -eval 'ecoveralls:travis_ci("_build/test/cover/ct.coverdata"), init:stop()'
+    - if [ $TRAVIS_OTP_RELEASE = "18.3" ]; then erl -noshell -pa _build/test/lib/*/ebin -eval 'ecoveralls:travis_ci("_build/test/cover/ct.coverdata"), init:stop()'; fi


### PR DESCRIPTION
Silent coveralls bot a bit, right now it pushes report for every otp_release and IMO it is too verbose