### PR TITLE
Restore elixir support

### DIFF
--- a/priv/app/function_browser.jsx
+++ b/priv/app/function_browser.jsx
@@ -193,8 +193,7 @@ export default class FunctionBrowser extends React.Component {
     var highlightedFun = this.refs.acm.highlightedFun();
 
     if (highlightedFun) {
-      funStr = Utils.formatMA(highlightedFun);
-      $(this.getSearchBox()).val(funStr);
+      $(this.getSearchBox()).val(highlightedFun);
       this.refs.acm.displayFuns([]);
     } else {
       var suggestedFuns = this.refs.acm.getFuns();

--- a/priv/app/graph.jsx
+++ b/priv/app/graph.jsx
@@ -156,6 +156,7 @@ export default class Graph extends React.Component {
 
     // Guess what? Dots in module name (and Elixir modules contains it - "Elixir.Enum":map/2) are problematic for ID.
     var safe_module = this.props.mfa[0].replace(/\./g, "-");
+    safe_module = safe_module.replace(/'/g, "");
 
     // And "*" is not a valid character too for an ID.
     if (arity === "*") {

--- a/priv/app/utils.js
+++ b/priv/app/utils.js
@@ -12,6 +12,7 @@ export default class Utils {
   }
 
   static formatMFA(MFA) {
+
     if (MFA.length !== 3) {
       throw new Error(`Unexpected argument passed to the formatter (MFA length: ${MFA.length}).`);
     }
@@ -32,14 +33,17 @@ export default class Utils {
       throw new Error("Function name is an empty string.");
     }
 
-    if (!Utils.can_be_unescaped_atom(MFA[0])) {
-      MFA[0] = `'${MFA[0]}'`;
+    let OutMFA = [ MFA[0], MFA[1], MFA[2] ];
+
+    if (!Utils.can_be_unescaped_atom(OutMFA[0])) {
+      OutMFA[0] = `'${OutMFA[0]}'`;
     }
 
-    if (!Utils.can_be_unescaped_atom(MFA[1])) {
-      MFA[1] = `'${MFA[1]}'`;
+    if (!Utils.can_be_unescaped_atom(OutMFA[1])) {
+      OutMFA[1] = `'${OutMFA[1]}'`;
     }
 
-    return `${MFA[0]}:${MFA[1]}/${MFA[2]}`;
+    return `${OutMFA[0]}:${OutMFA[1]}/${OutMFA[2]}`;
   }
+
 }

--- a/priv/build/bundle.js
+++ b/priv/build/bundle.js
@@ -1865,6 +1865,7 @@ webpackJsonp([0],[
 	
 	        // Guess what? Dots in module name (and Elixir modules contains it - "Elixir.Enum":map/2) are problematic for ID.
 	        var safe_module = this.props.mfa[0].replace(/\./g, "-");
+	        safe_module = safe_module.replace(/'/g, "");
 	
 	        // And "*" is not a valid character too for an ID.
 	        if (arity === "*") {
@@ -2430,6 +2431,7 @@ webpackJsonp([0],[
 	    key: "formatMFA",
 	    value: function () {
 	      function formatMFA(MFA) {
+	
 	        if (MFA.length !== 3) {
 	          throw new Error("Unexpected argument passed to the formatter (MFA length: " + MFA.length + ").");
 	        }
@@ -2450,15 +2452,17 @@ webpackJsonp([0],[
 	          throw new Error("Function name is an empty string.");
 	        }
 	
-	        if (!Utils.can_be_unescaped_atom(MFA[0])) {
-	          MFA[0] = "'" + MFA[0] + "'";
+	        var OutMFA = [MFA[0], MFA[1], MFA[2]];
+	
+	        if (!Utils.can_be_unescaped_atom(OutMFA[0])) {
+	          OutMFA[0] = "'" + OutMFA[0] + "'";
 	        }
 	
-	        if (!Utils.can_be_unescaped_atom(MFA[1])) {
-	          MFA[1] = "'" + MFA[1] + "'";
+	        if (!Utils.can_be_unescaped_atom(OutMFA[1])) {
+	          OutMFA[1] = "'" + OutMFA[1] + "'";
 	        }
 	
-	        return MFA[0] + ":" + MFA[1] + "/" + MFA[2];
+	        return OutMFA[0] + ":" + OutMFA[1] + "/" + OutMFA[2];
 	      }
 	
 	      return formatMFA;
@@ -21405,8 +21409,7 @@ webpackJsonp([0],[
 	        var highlightedFun = this.refs.acm.highlightedFun();
 	
 	        if (highlightedFun) {
-	          funStr = _utils2["default"].formatMA(highlightedFun);
-	          $(this.getSearchBox()).val(funStr);
+	          $(this.getSearchBox()).val(highlightedFun);
 	          this.refs.acm.displayFuns([]);
 	        } else {
 	          var suggestedFuns = this.refs.acm.getFuns();

--- a/priv/styles/main.css
+++ b/priv/styles/main.css
@@ -14,6 +14,7 @@ body {
   overflow: auto;
   text-overflow: ellipsis;
   font-family: monospace;
+  word-wrap: break-word;
 }
 
 .row-expanded div {

--- a/rebar.config
+++ b/rebar.config
@@ -16,7 +16,7 @@
 {deps,
  [{hdr_histogram, "0.2.0"},
   {cowboy, "1.0.4"},
-  {lager, "2.1.1"},
+  {lager, "3.2.4"},
   {jsone, "1.3.1"}
  ]}.
 


### PR DESCRIPTION
There are two things that make it problematic:
* lager version - In my case I had dependency clash on lager
* format MFA was not pure - it was altering MFA table that received on its input. For example the function was used for displaying purpose and every display spot added extra `'` escaping characters to the state variable. As a result we were sending invalid requests and displayed text was flipping 