### PR TITLE
Remove reenabling tracing in overflow scenario 

### DIFF
--- a/priv/app/tracing_switch.jsx
+++ b/priv/app/tracing_switch.jsx
@@ -4,7 +4,7 @@ import React from "react";
 export default class TracingSwitch extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { tracing: false };
+    this.state = { tracing: false, overflow: false };
   }
 
   componentDidMount() {
@@ -16,7 +16,7 @@ export default class TracingSwitch extends React.Component {
   }
 
   handleClick(event) {
-    var spec = this.state.tracing ? "pause" : "all";
+    var spec = this.state.tracing && !this.state.overflow ? "pause" : "all";
 
     $.ajax({
       url: "/api/trace_set",
@@ -33,6 +33,7 @@ export default class TracingSwitch extends React.Component {
     $.ajax({ url: "/api/trace_status" })
       .done((data) => {
         this.state.tracing = data.tracing;
+        this.state.overflow = data.overflow;
         this.setState(this.state);
       })
       .always(() =>
@@ -43,7 +44,13 @@ export default class TracingSwitch extends React.Component {
   render() {
     var symbol = "glyphicon glyphicon-" + (this.state.tracing ? "pause" : "record");
     var btnColor = "btn btn-" + (this.state.tracing ? "danger" : "success");
-    var text = this.state.tracing ? "Pause tracing" : "Trace all";
+    var text = "Pause tracing";
+    if (this.state.overflow) {
+      text = "Overflow! - resume trace all";
+      btnColor = "btn btn-warning";
+    } else if (!this.state.tracing) {
+      text = "Trace all";
+    }
 
     return (
       <form className="navbar-form navbar-left" role="search">

--- a/priv/app/tracing_switch.jsx
+++ b/priv/app/tracing_switch.jsx
@@ -4,7 +4,7 @@ import React from "react";
 export default class TracingSwitch extends React.Component {
   constructor(props) {
     super(props);
-    this.state = { tracing: false, overflow: false };
+    this.state = { status: "paused" };
   }
 
   componentDidMount() {
@@ -16,7 +16,7 @@ export default class TracingSwitch extends React.Component {
   }
 
   handleClick(event) {
-    var spec = this.state.tracing && !this.state.overflow ? "pause" : "all";
+    var spec = this.state.status === "running" ? "pause" : "all";
 
     $.ajax({
       url: "/api/trace_set",
@@ -32,8 +32,7 @@ export default class TracingSwitch extends React.Component {
   getTracingStatus() {
     $.ajax({ url: "/api/trace_status" })
       .done((data) => {
-        this.state.tracing = data.tracing;
-        this.state.overflow = data.overflow;
+        this.state.status = data.status;
         this.setState(this.state);
       })
       .always(() =>
@@ -42,14 +41,23 @@ export default class TracingSwitch extends React.Component {
   }
 
   render() {
-    var symbol = "glyphicon glyphicon-" + (this.state.tracing ? "pause" : "record");
-    var btnColor = "btn btn-" + (this.state.tracing ? "danger" : "success");
-    var text = "Pause tracing";
-    if (this.state.overflow) {
+    var symbol = "glyphicon glyphicon-";
+    var btnColor = "btn btn-";
+    var text = "";
+    let status = this.state.status;
+
+    if (status === "running") {
+      text = "Pause Tracing";
+      symbol += "pause";
+      btnColor += "danger";
+    } else if (status === "paused") {
+      text = "Trace All";
+      symbol += "record";
+      btnColor += "success";
+    } else if (status === "overflow") {
       text = "Overflow! - resume trace all";
-      btnColor = "btn btn-warning";
-    } else if (!this.state.tracing) {
-      text = "Trace all";
+      symbol += "record";
+      btnColor += "warning";
     }
 
     return (

--- a/src/xprof_tracer.erl
+++ b/src/xprof_tracer.erl
@@ -158,16 +158,6 @@ code_change(_OldVsn, State, _Extra) ->
 init_tracer() ->
     erlang:trace_pattern({'_','_','_'}, false, [local]).
 
-check_for_overflow(State = #state{paused=false, overflow=true,
-                                  trace_spec=TraceSpec}) ->
-    {_, QLen} = erlang:process_info(self(), message_queue_len),
-    case QLen =< 100 of
-        true ->
-            set_trace_opts(true, TraceSpec),
-            State#state{overflow=false};
-        false ->
-            State
-    end;
 check_for_overflow(State = #state{paused=false, overflow=false,
                                   trace_spec=TraceSpec}) ->
     {_, QLen} = erlang:process_info(self(), message_queue_len),
@@ -188,7 +178,7 @@ setup_trace(resume, State = #state{trace_spec=Spec}) ->
     setup_trace(Spec, State#state{trace_spec=undefined});
 setup_trace(Spec, State = #state{trace_spec=undefined}) ->
     set_trace_opts(true, Spec),
-    State#state{trace_spec=Spec, paused=false};
+    State#state{trace_spec=Spec, paused=false, overflow=false};
 setup_trace(Spec, State) ->
     set_trace_opts(false, State#state.trace_spec),
     setup_trace(Spec, State#state{trace_spec=undefined}).

--- a/src/xprof_tracer.erl
+++ b/src/xprof_tracer.erl
@@ -21,10 +21,9 @@
          terminate/2,
          code_change/3]).
 
--record(state, {trace_spec  = all,   %% trace specification
-                paused      = true,  %% tracing paused?
-                overflow    = false, %% tracing is paused because of overflow?
-                funs        = []     %% functions monitored by xprof
+-record(state, {trace_spec  = all,    %% trace specification
+                status      = paused, %% tracing status
+                funs        = []      %% functions monitored by xprof
                }).
 
 %% @doc Starts xprof tracer process.
@@ -108,9 +107,8 @@ handle_call({trace, PidSpec}, _From, State) ->
     NewState = setup_trace(PidSpec, State),
     {reply, ok, NewState};
 handle_call(trace_status, _From, State = #state{trace_spec=TraceSpec,
-                                                paused=Paused,
-                                                overflow=Overflow}) ->
-    {reply, {TraceSpec, Paused, Overflow}, State};
+                                                status=Status}) ->
+    {reply, {TraceSpec, Status}, State};
 handle_call(_Request, _From, State) ->
     {reply, ignored, State}.
 
@@ -158,13 +156,13 @@ code_change(_OldVsn, State, _Extra) ->
 init_tracer() ->
     erlang:trace_pattern({'_','_','_'}, false, [local]).
 
-check_for_overflow(State = #state{paused=false, overflow=false,
+check_for_overflow(State = #state{status = running,
                                   trace_spec=TraceSpec}) ->
     {_, QLen} = erlang:process_info(self(), message_queue_len),
     case QLen >= 1000 of
         true ->
             set_trace_opts(false, TraceSpec),
-            State#state{overflow=true};
+            State#state{status=overflow};
         false ->
             State
     end;
@@ -173,12 +171,12 @@ check_for_overflow(State) ->
 
 setup_trace(pause, State) ->
     set_trace_opts(false, State#state.trace_spec),
-    State#state{paused = true};
+    State#state{status=paused};
 setup_trace(resume, State = #state{trace_spec=Spec}) ->
     setup_trace(Spec, State#state{trace_spec=undefined});
 setup_trace(Spec, State = #state{trace_spec=undefined}) ->
     set_trace_opts(true, Spec),
-    State#state{trace_spec=Spec, paused=false, overflow=false};
+    State#state{trace_spec=Spec, status=running};
 setup_trace(Spec, State) ->
     set_trace_opts(false, State#state.trace_spec),
     setup_trace(Spec, State#state{trace_spec=undefined}).

--- a/src/xprof_web_handler.erl
+++ b/src/xprof_web_handler.erl
@@ -100,8 +100,8 @@ handle_req(<<"trace_set">>, Req, State) ->
     {ok, ResReq, State};
 
 handle_req(<<"trace_status">>, Req, State) ->
-    {_, Paused, Overflow} = xprof_tracer:trace_status(),
-    Json = jsone:encode({[{tracing, not Paused}, {overflow, Overflow}]}),
+    {_, Status} = xprof_tracer:trace_status(),
+    Json = jsone:encode({[{status, Status}]}),
     {ok, ResReq} = cowboy_req:reply(200,
                                     [{<<"content-type">>,
                                       <<"application/json">>}],

--- a/src/xprof_web_handler.erl
+++ b/src/xprof_web_handler.erl
@@ -100,8 +100,8 @@ handle_req(<<"trace_set">>, Req, State) ->
     {ok, ResReq, State};
 
 handle_req(<<"trace_status">>, Req, State) ->
-    {_, Paused, _} = xprof_tracer:trace_status(),
-    Json = jsone:encode({[{tracing, not Paused}]}),
+    {_, Paused, Overflow} = xprof_tracer:trace_status(),
+    Json = jsone:encode({[{tracing, not Paused}, {overflow, Overflow}]}),
     {ok, ResReq} = cowboy_req:reply(200,
                                     [{<<"content-type">>,
                                       <<"application/json">>}],

--- a/test/xprof_tracing_SUITE.erl
+++ b/test/xprof_tracing_SUITE.erl
@@ -45,7 +45,7 @@ pid_tracing(Config) ->
 
 basic_tracing(PidSpec, Config) ->
     ok = xprof_tracer:trace(PidSpec),
-    ?assertMatch({PidSpec, false, false}, xprof_tracer:trace_status()),
+    ?assertMatch({PidSpec, running}, xprof_tracer:trace_status()),
 
     Last = get_print_current_time(),
 
@@ -63,13 +63,13 @@ basic_tracing(PidSpec, Config) ->
     ?assert(0 =< proplists:get_value(count, Items2)),
 
     xprof_tracer:trace(pause),
-    ?assertMatch({PidSpec, true, false}, xprof_tracer:trace_status()),
+    ?assertMatch({PidSpec, paused}, xprof_tracer:trace_status()),
     ok.
 
 
 spawner_tracing(Config) ->
     ok = xprof_tracer:trace({spawner, self(), 1.0}),
-    ?assertMatch({{spawner, _Pid, 1.0}, false, false},
+    ?assertMatch({{spawner, _Pid, 1.0}, running},
                  xprof_tracer:trace_status()),
 
     Last = get_print_current_time(),
@@ -88,7 +88,7 @@ spawner_tracing(Config) ->
     ?assert(0 =< proplists:get_value(count, Items2)),
 
     xprof_tracer:trace(pause),
-    ?assertMatch({{spawner, _Pid, 1.0}, true, false},
+    ?assertMatch({{spawner, _Pid, 1.0}, paused},
                  xprof_tracer:trace_status()),
     ok.
 
@@ -97,11 +97,11 @@ dead_proc_tracing(_Config) ->
     %% wait for the process to terminate
     receive {'DOWN', MRef, _, _, _} -> ok end,
     ok = xprof_tracer:trace(Pid),
-    ?assertMatch({Pid, false, false},
+    ?assertMatch({Pid, running},
                  xprof_tracer:trace_status()),
 
     ok = xprof_tracer:trace({spawner, Pid, 1.0}),
-    ?assertMatch({{spawner, Pid, 1.0}, false, false},
+    ?assertMatch({{spawner, Pid, 1.0}, running},
                  xprof_tracer:trace_status()),
     ok.
 


### PR DESCRIPTION
This flipping mode is is dangerous and all in all graf is inaccurate.
Make user the one who decides if we should continue. This commit closes #24