### PR TITLE
Replace all weird chars when creating chart ids

### DIFF
--- a/priv/app/graph.jsx
+++ b/priv/app/graph.jsx
@@ -152,12 +152,7 @@ export default class Graph extends React.Component {
   }
 
   chartId() {
-    var formatted_mfa = Utils.formatMFA(this.props.mfa);
-
-    // Characters that have special meaning in CSS selectors are not safe in an ID.
-    // (eg ':', '.', '?', '*' or single quote itself)
-    // (A very problematic example: "'Elixir.List':'keymember?'/*")
-    return "chart_" + formatted_mfa.replace(/[^A-Za-z0-9_-]/g, "-");
+    return Utils.chartId(this.props.mfa);
   }
 
 }

--- a/priv/app/graph.jsx
+++ b/priv/app/graph.jsx
@@ -152,17 +152,12 @@ export default class Graph extends React.Component {
   }
 
   chartId() {
-    var arity = this.props.mfa[2];
+    var formatted_mfa = Utils.formatMFA(this.props.mfa);
 
-    // Guess what? Dots in module name (and Elixir modules contains it - "Elixir.Enum":map/2) are problematic for ID.
-    var safe_module = this.props.mfa[0].replace(/\./g, "-");
-    safe_module = safe_module.replace(/'/g, "");
-
-    // And "*" is not a valid character too for an ID.
-    if (arity === "*") {
-      arity = "x";
-    }
-
-    return `chart_${safe_module}_${this.props.mfa[1]}_${arity}`;
+    // Characters that have special meaning in CSS selectors are not safe in an ID.
+    // (eg ':', '.', '?', '*' or single quote itself)
+    // (A very problematic example: "'Elixir.List':'keymember?'/*")
+    return "chart_" + formatted_mfa.replace(/[^A-Za-z0-9_-]/g, "-");
   }
+
 }

--- a/priv/app/utils.js
+++ b/priv/app/utils.js
@@ -46,6 +46,16 @@ export default class Utils {
     return `${OutMFA[0]}:${OutMFA[1]}/${OutMFA[2]}`;
   }
 
+
+  static chartId(MFA) {
+    var formatted_mfa = this.formatMFA(MFA);
+
+    // Characters that have special meaning in CSS selectors are not safe in an ID.
+    // (eg ':', '.', '?', '*' or single quote itself)
+    // (A very problematic example: "'Elixir.List':'keymember?'/*")
+    return "chart_" + formatted_mfa.replace(/[^A-Za-z0-9_-]/g, "-");
+  }
+
   static commonArrayPrefix(sortedArray) {
     var string1 = sortedArray[0];
     var string2 = sortedArray[sortedArray.length - 1];

--- a/priv/test/formatting_MFA.test.js
+++ b/priv/test/formatting_MFA.test.js
@@ -81,6 +81,45 @@ describe("Formatting MFA should be compatible with 'Erlang' specificity", functi
   });
 });
 
+describe("Generating valid id tag for the charts", function() {
+  describe("Simple Erlang modules", function() {
+    it("erlang:process_info/1", function() {
+      expect(Utils.chartId([ "erlang", "process_info", 1 ])).to.be.equal("chart_erlang-process_info-1");
+    });
+
+    it("custom_module:function/99", function() {
+      expect(Utils.chartId([ "custom_module", "function", 99 ])).to.be.equal("chart_custom_module-function-99");
+    });
+  });
+
+  describe("Match-spec function", function() {
+    it("ets:lookup/*", function() {
+      expect(Utils.chartId([ "ets", "lookup", "*" ])).to.be.equal("chart_ets-lookup--");
+    });
+  });
+
+  describe("Elixir modules", function() {
+    it("'Elixir.Enum':map/2", function() {
+      expect(Utils.chartId([ "Elixir.Enum", "map", 2 ])).to.be.equal("chart_-Elixir-Enum--map-2");
+    });
+
+    it("'Elixir.Process':'is_alive?'/1", function() {
+      expect(Utils.chartId([ "Elixir.Process", "alive?", 1 ])).to.be.equal("chart_-Elixir-Process---alive---1");
+    });
+  });
+
+  describe("Weird characters", function() {
+    it("a0@a:'Abc'/0", function() {
+      expect(Utils.chartId([ "a0@a", "Abc", 0 ])).to.be.equal("chart_a0-a--Abc--0");
+    });
+
+    it("'Erlang $!':'is_fun!'/1", function() {
+      expect(Utils.chartId([ "Erlang $!", "is_fun!", 1 ])).to.be.equal("chart_-Erlang------is_fun---1");
+    });
+  });
+
+});
+
 describe("Find common prefix", function() {
   it("No common prefix", function() {
     expect(Utils.commonArrayPrefix([ "aaa", "bbb", "ccc" ])).to.be.equal("");


### PR DESCRIPTION
In quoted atoms any characters can occure and Elixir makes use of many
of them.