### PR TITLE
Bugfix: calls longer than 1 second were silently ignored

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Key                    | Default     | Description
 :----------------------|:------------|:-----------
 `port`                 | 7890        |Port for the web interface
 `max_tracer_queue_len` | 1000        | Overflow protection. If main tracer proccess will have more than 1000 messages in its process queue tracing will be stopped and one needs to use trace button to resume. The purpose of this is to prevent out of memory crashes when tracer process is not able to process incomming traces fast enough. This may happen when we trace very "hot" function.
+`max_duration`         | 30000       | The largest duration value in ms. In case a call takes even longer, this maximum value is stored instead.
 
 ## XProf flavoured match-spec funs
 

--- a/src/xprof_tracer.erl
+++ b/src/xprof_tracer.erl
@@ -72,7 +72,7 @@ trace(PidOrSpec) ->
 
 %% @doc Returns current tracing state.
 -spec trace_status() -> {all | {spawner, pid(), float()} | pid(),
-                         Paused :: boolean(), Overflow :: boolean()}.
+                         Status :: paused | running | overflow}.
 trace_status() ->
     gen_server:call(?MODULE, trace_status).
 

--- a/src/xprof_tracer_handler.erl
+++ b/src/xprof_tracer_handler.erl
@@ -21,13 +21,13 @@
          terminate/2,
          code_change/3]).
 
--record(state, {mfa, name, last_ts, hdr_ref, window_size,
+-record(state, {mfa, name, last_ts, hdr_ref, window_size, max_duration,
                 capture_spec, capture_id=0, capture_counter=0}).
 
 -define(ONE_SEC, 1000000). %% Second in microseconds
 -define(WINDOW_SIZE, 10*60). %% 10 min window size
-%% The largest duration value that can be stored in the HDR histogram
--define(MAX_DURATION, 30*?ONE_SEC).
+%% The largest duration value that can be stored in the HDR histogram in ms
+-define(MAX_DURATION, 30*1000).
 
 %% @doc Starts new process registered localy.
 -spec start_link(xprof:mfaspec()) -> {ok, pid()}.
@@ -97,12 +97,15 @@ get_captured_data(MFA, Offset) ->
 %% gen_server callbacks
 
 init([MFA, Name]) ->
-    {ok, HDR} = init_storage(Name),
+    MaxDuration =
+        application:get_env(xprof, max_duration, ?MAX_DURATION) * 1000,
+    {ok, HDR} = init_storage(Name, MaxDuration),
     %% add trace pattern with args capturing turned off
     capture_args_trace_off(MFA),
     {ok, #state{mfa=MFA, hdr_ref=HDR, name=Name,
                 last_ts=os:timestamp(),
-                window_size=?WINDOW_SIZE}, 1000}.
+                window_size=?WINDOW_SIZE,
+                max_duration = MaxDuration}, 1000}.
 
 handle_call({capture, Threshold, Limit}, _From,
             State = #state{mfa = MFA}) ->
@@ -164,10 +167,10 @@ code_change(_OldVsn, State, _Extra) ->
 
 %% Internal functions
 
-init_storage(Name) ->
+init_storage(Name, MaxDuration) ->
     ets:new(Name, [public, named_table]),
     ets:insert(Name, {capture_spec, -1, -1, -1, -1}),
-    hdr_histogram:open(?MAX_DURATION, 3).
+    hdr_histogram:open(MaxDuration * 1000, 3).
 
 maybe_make_snapshot(State = #state{name=Name, last_ts=LastTS,
                                    window_size=WindSize}) ->
@@ -256,12 +259,14 @@ record_results(Pid, CallTime, Args, Res,
                State = #state{mfa = MFA,
                               name = Name,
                               hdr_ref = Ref,
+                              max_duration = MaxDuration,
                               capture_spec = CaptureSpec,
                               capture_counter = Count}) ->
-    if CallTime > ?MAX_DURATION ->
+    if CallTime > MaxDuration ->
             lager:error("Call ~p took ~p ms that is larger than the maximum "
-                        "that can be stored", [Name, CallTime/1000]),
-            ok = hdr_histogram:record(Ref, ?MAX_DURATION);
+                        "that can be stored (~p ms)",
+                        [Name, CallTime/1000, MaxDuration div 1000]),
+            ok = hdr_histogram:record(Ref, MaxDuration);
        true ->
             ok = hdr_histogram:record(Ref, CallTime)
     end,

--- a/src/xprof_tracer_handler.erl
+++ b/src/xprof_tracer_handler.erl
@@ -62,10 +62,15 @@ capture(MFA = {M,F,A}, Threshold, Limit) ->
     Name = xprof_lib:mfa2atom(MFA),
     gen_server:call(Name, {capture, Threshold, Limit}).
 
--spec capture_stop(xprof:mfaid()) -> ok.
+-spec capture_stop(xprof:mfaid()) -> ok | {error, not_found}.
 capture_stop(MFA) ->
     Name = xprof_lib:mfa2atom(MFA),
-    gen_server:call(Name, capture_stop).
+    try
+        gen_server:call(Name, capture_stop)
+    catch
+        exit:{noproc, _} ->
+            {error, not_found}
+    end.
 
 %% @doc
 -spec get_captured_data(mfa(), non_neg_integer()) ->

--- a/src/xprof_web_handler.erl
+++ b/src/xprof_web_handler.erl
@@ -135,8 +135,8 @@ handle_req(<<"capture_stop">>, Req, State) ->
         case xprof_tracer_handler:capture_stop(MFA) of
             ok ->
                 cowboy_req:reply(204, Req);
-            {error, _Reason} ->
-                cowboy_req:reply(500, Req)
+            {error, not_found} ->
+                cowboy_req:reply(404, Req)
         end,
     {ok, ResReq, State};
 handle_req(<<"capture_data">>, Req, State) ->

--- a/test/xprof_http_e2e_SUITE.erl
+++ b/test/xprof_http_e2e_SUITE.erl
@@ -152,7 +152,7 @@ no_capture_data_when_not_traced(_Config) ->
 
 error_when_stopping_not_started_capture(_Config) ->
     MFA = [{"mod", "xprof_http_e2e_SUITE"}, {"fun", "long_function"}, {"arity", "0"}],
-    ?assertMatch({500, _}, make_get_request("api/capture_stop", MFA)),
+    ?assertMatch({404, _}, make_get_request("api/capture_stop", MFA)),
     ok.
 
 capture_data_when_traced_test(_Config) ->


### PR DESCRIPTION
 Calls that took more than 1 second were although visible when data
capturing is enabled they were not recorded by
hdr_histogram. hdr_histogram is started with a maximum value which was
set to 1e6 (microseconds) and when trying to store larger values the
`record/2` call returned {error, value_out_of_range} which was ignored.

Make `max_duration` configurable (defaults to increased value of 30 seconds),
and in case a call takes even longer than this, store the max value and emit an error log.

While at it fix some unrelated dialyzer warnings