### PR TITLE
Workaround for Firefox strangeness

### DIFF
--- a/test/xprof_http_e2e_SUITE.erl
+++ b/test/xprof_http_e2e_SUITE.erl
@@ -60,8 +60,8 @@ get_running_status_after_setting_tracing(_Config) ->
     ok.
 
 trace_set_only_accepts_all_and_pause(_Config) ->
-    ?assertMatch({200, _}, make_get_request("api/trace_set", [{"spec", "all"}])),
-    ?assertMatch({200, _}, make_get_request("api/trace_set", [{"spec", "pause"}])),
+    ?assertMatch({204, _}, make_get_request("api/trace_set", [{"spec", "all"}])),
+    ?assertMatch({204, _}, make_get_request("api/trace_set", [{"spec", "pause"}])),
     ?assertMatch({400, _}, make_get_request("api/trace_set", [{"spec", "invalid"}])),
     ok.
 
@@ -192,7 +192,7 @@ dont_receive_new_capture_data_after_stop(_Config) ->
 %% Givens
 %%
 given_tracing_all() ->
-    {200, _} = make_get_request("api/trace_set", [{"spec", "all"}]),
+    {204, _} = make_get_request("api/trace_set", [{"spec", "all"}]),
     ok.
 
 given_overload_queue_limit(Limit) ->


### PR DESCRIPTION
In case an ajax/xmlHTTPRequest receives no content with no-content type
(no matter if it is 200 or 204) current Firefox version will emit the following error:
"XML Parsing Error: no root element found..."

As a workaround always return content-type: octet-stream for successful
responses which have no body.