### PR TITLE
Improve search box suggestion list

### DIFF
--- a/priv/app/function_browser.jsx
+++ b/priv/app/function_browser.jsx
@@ -145,6 +145,8 @@ export default class FunctionBrowser extends React.Component {
         // Try to complete using selected suggestion
         e.preventDefault();
         this.completeSearch();
+        // Refetch list of functions
+        this.handleChange(e);
         break;
 
       // ARROW UP
@@ -192,14 +194,20 @@ export default class FunctionBrowser extends React.Component {
     var highlightedFun = this.refs.acm.highlightedFun();
 
     if (highlightedFun) {
-      $(this.getSearchBox()).val(highlightedFun);
-      this.refs.acm.displayFuns([]);
+      this.maybeSetSearchBox(highlightedFun);
     } else {
       var suggestedFuns = this.refs.acm.getFuns();
       if (suggestedFuns.length > 0) {
         var prefix = Utils.commonArrayPrefix(suggestedFuns);
-        $(this.getSearchBox()).val(prefix);
+        this.maybeSetSearchBox(prefix);
       }
+    }
+  }
+
+  maybeSetSearchBox(newValue) {
+    // Don't modify search box content if it is not a prefix of the new value, don't want to overwrite a match-spec fun (for which there are still suggestions) that is being edited with some arity.
+    if (newValue.startsWith(this.getSearchBox().value)) {
+      this.getSearchBox().value = newValue;
     }
   }
 

--- a/src/xprof_web_handler.erl
+++ b/src/xprof_web_handler.erl
@@ -29,10 +29,8 @@ terminate(_Reason, _Req, _State) ->
 handle_req(<<"funs">>, Req, State) ->
     {Query, _} = cowboy_req:qs_val(<<"query">>, Req, <<"">>),
 
-    ModeCb = xprof_lib:get_mode_cb(),
     Funs = lists:sort(
-             [ModeCb:fmt_mfa(Mod, Fun, Arity)
-              || {Mod, Fun, Arity} <- xprof_vm_info:get_available_funs(Query)]),
+             xprof_vm_info:get_available_funs(Query)),
     Json = jsone:encode(Funs),
 
     lager:debug("Returning ~b functions matching phrase \"~s\"",

--- a/test/xprof_test_lib.erl
+++ b/test/xprof_test_lib.erl
@@ -33,6 +33,7 @@ setup_elixir(ElixirEbin) ->
                 true = code:add_patha(ElixirEbin),
                 ElixirEbin
         end,
+    application:unset_env(xprof, mode),
     {ok, Apps} = application:ensure_all_started(elixir),
     {ElixirEbin1, Apps}.
 
@@ -49,6 +50,7 @@ get_elixir_ebin(Elixir) ->
     end.
 
 cleanup_elixir({ElixirEbin, Apps}) ->
+    application:unset_env(xprof, mode),
     [ok = application:stop(App) || App <- Apps],
     del_elixir_from_path(ElixirEbin),
     ok.

--- a/test/xprof_vm_info_tests.erl
+++ b/test/xprof_vm_info_tests.erl
@@ -12,23 +12,23 @@ get_available_funs_test_() ->
              ?assertEqual([], L2 -- L1),
              ?assertNotEqual([], L1 -- L2)
      end,
-     {"Only global functions are listed",
+     {"Only module names are listed",
       fun() ->
               L1 = ?M:get_available_funs(<<"xprof_vm_info">>),
-              ?assert(lists:member({?M, get_available_funs, 1}, L1)),
-              ?assertNot(lists:member({?M, filter_funs, 3}, L1))
+              ?assert(lists:member(<<"xprof_vm_info:">>, L1)),
+              ?assertNot(lists:member(<<"xprof_vm_info:get_available_funs/1">>, L1))
       end},
      {"Module info is filtered out",
       fun() ->
-              L1 = ?M:get_available_funs(<<"xprof_vm_info">>),
-              ?assertNot(lists:member({?M, module_info, 0}, L1)),
-              ?assertNot(lists:member({?M, module_info, 1}, L1))
+              L1 = ?M:get_available_funs(<<"xprof_vm_info:">>),
+              ?assertNot(lists:member(<<"xprof_vm_info:module_info/0">>, L1)),
+              ?assertNot(lists:member(<<"xprof_vm_info:module_info/1">>, L1))
       end},
      {"Local functions are also listed if query contains colon",
       fun() ->
               L1 = ?M:get_available_funs(<<"xprof_vm_info:">>),
-              ?assert(lists:member({?M, get_available_funs, 1}, L1)),
-              ?assert(lists:member({?M, filter_funs, 3}, L1))
+              ?assert(lists:member(<<"xprof_vm_info:get_available_funs/1">>, L1)),
+              ?assert(lists:member(<<"xprof_vm_info:filter_funs/3">>, L1))
       end},
      {"Generated functions are filtered out",
       fun() ->
@@ -47,18 +47,18 @@ get_available_funs_test_() ->
      {"Arity matching",
       fun() ->
               L1 = ?M:get_available_funs(<<"xprof_vm_info:get_available_funs/">>),
-              ?assertEqual([{?M, get_available_funs, 1}], L1),
+              ?assertEqual([<<"xprof_vm_info:get_available_funs/1">>], L1),
               L2 = ?M:get_available_funs(<<"xprof_vm_info:get_available_funs/1">>),
-              ?assertEqual([{?M, get_available_funs, 1}], L2),
+              ?assertEqual([<<"xprof_vm_info:get_available_funs/1">>], L2),
               L3 = ?M:get_available_funs(<<"xprof_vm_info:get_available_funs/99">>),
               ?assertEqual([], L3)
       end},
      {"Match-spec fun matching",
       fun() ->
               L1 = ?M:get_available_funs(<<"xprof_vm_info:get_available_funs(_) ->">>),
-              ?assertEqual([{?M, get_available_funs, 1}], L1),
+              ?assertEqual([<<"xprof_vm_info:get_available_funs/1">>], L1),
               L2 = ?M:get_available_funs(<<"xprof_vm_info:get_available_funs message(get_tcw())">>),
-              ?assertEqual([{?M, get_available_funs, 1}], L2)
+              ?assertEqual([<<"xprof_vm_info:get_available_funs/1">>], L2)
       end}
     ].
 
@@ -70,25 +70,25 @@ weird_atoms_test_() ->
       {"Module name with special character",
        fun() ->
                L1 = ?M:get_available_funs(<<"'A.B">>),
-               ?assertEqual([{'A.B.C', h, 10}], L1),
+               ?assertEqual([<<"'A.B.C':">>], L1),
                L2 = ?M:get_available_funs(<<"'A.B.C':">>),
-               ?assertEqual([{'A.B.C', 'f?', 0},
-                             {'A.B.C', 'g\'g', 0},
-                             {'A.B.C', h, 1},
-                             {'A.B.C', h, 10}
+               ?assertEqual([<<"'A.B.C':'f?'/0">>,
+                             <<"'A.B.C':'g\\'g'/0">>,
+                             <<"'A.B.C':h/1">>,
+                             <<"'A.B.C':h/10">>
                             ], L2)
        end},
       {"Function name with special character",
        fun() ->
                L1 = ?M:get_available_funs(<<"'A.B.C':'f">>),
-               ?assertEqual([{'A.B.C', 'f?', 0}], L1),
+               ?assertEqual([<<"'A.B.C':'f?'/0">>], L1),
                L2 = ?M:get_available_funs(<<"'A.B.C':'g">>),
-               ?assertEqual([{'A.B.C', 'g\'g', 0}], L2)
+               ?assertEqual([<<"'A.B.C':'g\\'g'/0">>], L2)
        end},
       {"Multiple arity matches",
        fun() ->
                L1 = ?M:get_available_funs(<<"'A.B.C':h/1">>),
-               ?assertEqual([{'A.B.C', h, 1}, {'A.B.C', h, 10}], L1)
+               ?assertEqual([<<"'A.B.C':h/1">>, <<"'A.B.C':h/10">>], L1)
        end}
      ]}.
 


### PR DESCRIPTION
Only show module names when no module is complete. Show all functions
for modules complete with delimiter.