### PR TITLE
Refactor internal represenation of what to trace

### DIFF
--- a/src/xprof.erl
+++ b/src/xprof.erl
@@ -9,20 +9,21 @@
 -type ms() :: [tuple()].
 %% traced function with optional match-spec
 %% used to initiate tracing (both by xprof_tracer and xprof_tracer_handler)
--type mfaspec() :: mfa() | {module(), atom(), {ms(), ms()}}.
+-type mfa_spec() :: {mfa_id(), {ms(), ms()}}.
 
 %% used by gui and xprof_tracer to identify mfas
-%% arity of '*' means all arities
--type mfaid() :: {module(), atom(), arity() | '*'}.
+%% arity of '_' means all arities
+%% similar to type erlang:trace_pattern_mfa()
+-type mfa_id() :: {module(), atom(), arity() | '_'}.
 
-%% derived from mfaid
+%% derived from mfa_id
 %% used to register ets tables and xprof_tracer_handler gen_servers
--type mfaname() :: atom().
+-type mfa_name() :: atom().
 
 %% accepted syntax mode
 -type mode() :: erlang | elixir.
 
--export_type([mfaspec/0, mfaid/0, mfaname/0, mode/0]).
+-export_type([mfa_spec/0, mfa_id/0, mfa_name/0, mode/0]).
 
 
 start() ->

--- a/src/xprof_elixir_syntax.erl
+++ b/src/xprof_elixir_syntax.erl
@@ -64,13 +64,13 @@ build_fn(Clauses) ->
 %% "Mod.fun Args" => "Mod.fun(Args)"
 %% "Mod.fun" => "Mod.fun()"
 -spec parse_quoted(ex_quoted())
-    -> {mfa, module(), atom(), arity()}
+    -> {mfa, mfa()}
      | {clauses, module(), atom(), [erl_parse:abstract_clause()]}.
 %% Mod.fun/Arity
 parse_quoted({'/', _, [?mfargs(ModQ, Fun, []), Arity]})
   when is_atom(Fun), is_integer(Arity) ->
     Mod = mod_to_atom(ModQ),
-    {mfa, Mod, Fun, Arity};
+    {mfa, {Mod, Fun, Arity}};
 %% "Mod.fun(Args)"
 parse_quoted(?mfargs(ModQ, Fun, Args)) when is_atom(Fun) ->
     Mod = mod_to_atom(ModQ),

--- a/src/xprof_erlang_syntax.erl
+++ b/src/xprof_erlang_syntax.erl
@@ -21,7 +21,7 @@
 %% of the clauses of the anonimous function.
 parse_query(Str) ->
     case tokens(Str) of
-        {mfa, _M, _F, _Arity} = MFA ->
+        {mfa, _} = MFA ->
             MFA;
         {clauses, M, F, Tokens} ->
             Clauses = parse(Tokens),
@@ -35,7 +35,7 @@ tokens(Str) ->
         {ok, [{atom, _, M}, {':', _},
               {atom, _, F}, {'/', _},
               {integer, _, A}], _EndLoc} ->
-            {mfa, M, F, A};
+            {mfa, {M, F, A}};
         {ok, [{atom, _, M}, {':', _},
               {atom, _, F}|Tokens], _EndLoc} when Tokens =/= [] ->
             {clauses, M, F, [{'fun', 0}|ensure_end(ensure_body(Tokens))]};

--- a/src/xprof_language.erl
+++ b/src/xprof_language.erl
@@ -7,8 +7,7 @@
 %% Function for start monitoring
 
 -callback parse_query(Query :: string()) ->
-    Result :: {mfa, module(), atom(), arity()}
-            | {mfa, module(), atom(), '*'}
+    Result :: {mfa, xprof:mfa_id()}
             | {clauses, module(), atom(), [erl_parse:abstract_clause()]}.
 
 %% Functions for autocomplete

--- a/src/xprof_lib.erl
+++ b/src/xprof_lib.erl
@@ -1,6 +1,7 @@
 -module(xprof_lib).
 
--export([mfa2atom/1,
+-export([mfaspec2atom/1,
+         mfa2atom/1,
          mfaspec2id/1,
          now2epoch/1,
          set_mode/1,
@@ -10,25 +11,21 @@
          prefix_rest/2
         ]).
 
--spec mfa2atom(xprof_tracer:mfaspec() | xprof_tracer:mfaid()) ->
-                      xprof_tracer:mfaname().
-mfa2atom({M, F, {_MSOff, _MSOn}}) ->
-    mfa2atom({M, F, '*'});
-mfa2atom({M, F, '*'}) ->
+-spec mfaspec2atom(xprof:mfa_spec()) -> xprof:mfa_name().
+mfaspec2atom({MFAId, {_MSOff, _MSOn}}) ->
+    mfa2atom(MFAId).
+
+-spec mfa2atom(xprof:mfa_id()) -> xprof:mfa_name().
+mfa2atom({M, F, '_'}) ->
     list_to_atom(string:join(["xprof_", atom_to_list(M),
-                              atom_to_list(F), "*"], "_"));
+                              atom_to_list(F), "_"], "_"));
 mfa2atom({M,F,A}) ->
     list_to_atom(string:join(["xprof_", atom_to_list(M),
                               atom_to_list(F), integer_to_list(A)], "_")).
 
-
--spec mfaspec2id(xprof:mfaspec()) -> xprof:mfaid().
-mfaspec2id({M, F, {_, _}})
-  when is_atom(M), is_atom(F) ->
-    {M, F, '*'};
-mfaspec2id({M, F, A} = MFA)
-  when is_atom(M), is_atom(F), is_integer(A) ->
-    MFA.
+-spec mfaspec2id(xprof:mfa_spec()) -> xprof:mfa_id().
+mfaspec2id({MFAId, {_, _}}) ->
+    MFAId.
 
 now2epoch({MS, S, _US}) ->
     MS * 1000000 + S.

--- a/src/xprof_web_handler.erl
+++ b/src/xprof_web_handler.erl
@@ -175,13 +175,13 @@ handle_req(<<"capture_data">>, Req, State) ->
 
 %% Helpers
 
--spec get_mfa(cowboy:req()) -> xprof:mfaid().
+-spec get_mfa(cowboy:req()) -> xprof:mfa_id().
 get_mfa(Req) ->
     {Params, _} = cowboy_req:qs_vals(Req),
     {list_to_atom(binary_to_list(proplists:get_value(<<"mod">>, Params))),
      list_to_atom(binary_to_list(proplists:get_value(<<"fun">>, Params))),
      case proplists:get_value(<<"arity">>, Params) of
-         <<"*">> -> '*';
+         <<"_">> -> '_';
          Arity -> binary_to_integer(Arity)
      end}.
 

--- a/test/xprof_elixir_syntax_tests.erl
+++ b/test/xprof_elixir_syntax_tests.erl
@@ -7,13 +7,13 @@
 parse_query_test_() ->
     Tests =
         [%% arity explicitly defined
-         ?_assertEqual({mfa,'Elixir.Mod','fun',1},
+         ?_assertEqual({mfa,{'Elixir.Mod','fun',1}},
                        ?M:parse_query("Mod.fun/1")),
-         ?_assertEqual({mfa,'Elixir.Mod','fun',1},
+         ?_assertEqual({mfa,{'Elixir.Mod','fun',1}},
                        ?M:parse_query("Elixir.Mod.fun/1")),
-         ?_assertEqual({mfa,'Elixir.App.Mod','fun',1},
+         ?_assertEqual({mfa,{'Elixir.App.Mod','fun',1}},
                        ?M:parse_query("App.Mod.fun/1")),
-         ?_assertEqual({mfa,mod,'fun?',1},
+         ?_assertEqual({mfa,{mod,'fun?',1}},
                        ?M:parse_query(":mod.fun?/1")),
 
          %% full match-spec funs

--- a/test/xprof_http_e2e_SUITE.erl
+++ b/test/xprof_http_e2e_SUITE.erl
@@ -114,7 +114,7 @@ monitor_query_with_matchspec(_Config) ->
     Q = "lists:delete(_, [E]) -> true",
     ?assertMatch({204, _}, make_get_request("api/mon_start", [{"query", Q}])),
     {200, Monitored}  = make_get_request("api/mon_get_all"),
-    ?assertEqual([[<<"lists">>, <<"delete">>, <<"*">>, list_to_binary(Q)]],
+    ?assertEqual([[<<"lists">>, <<"delete">>, 2, list_to_binary(Q)]],
                  Monitored),
     ok.
 
@@ -132,7 +132,7 @@ get_data_for_not_traced_fun(_Config) ->
     ?assertMatch({404, _}, make_get_request("api/data", [
                                              {"mod", "dict"},
                                              {"fun", "new"},
-                                             {"arity", "*"}
+                                             {"arity", "_"}
                                             ])),
     ok.
 

--- a/test/xprof_tracing_SUITE.erl
+++ b/test/xprof_tracing_SUITE.erl
@@ -152,7 +152,7 @@ monitor_recursive_fun(_Config) ->
 
 monitor_ms(_Config) ->
     Query = ?MODULE_STRING ++ ":test_fun(T) when T < 5 -> true.",
-    MFA = {?MODULE, test_fun, '*'},
+    MFA = {?MODULE, test_fun, 1},
     xprof_tracer:monitor(Query),
     ?assertEqual([{MFA, list_to_binary(Query)}], xprof_tracer:all_monitored()),
 
@@ -221,7 +221,7 @@ capture_args_res(_Config) ->
 
 capture_args_ms(_Config) ->
     Query = ?MODULE_STRING ++ ":test_fun(T) -> message({time, T}).",
-    MFA = {?MODULE, test_fun, '*'},
+    MFA = {?MODULE, test_fun, 1},
     xprof_tracer:monitor(Query),
     ok = xprof_tracer:trace(self()),
 


### PR DESCRIPTION
- mfa_id() is {mod, fun, arity}. Though arity can be '_' there is no way
  currently to initiate such monitoring. Monitoring of functions with any airty
  can be implemented later if deemed useful.

- mfa_spec() holds {mfa_id(), {MSOff, MSOn}} for all kinds of monitoring
  queries. (Even for queries in the format of "mod:fun/arity" without any
  match-spec fun). MSOff is the match-spec to be used when argument capturing is
  disabled and MSOn is the match-spec when argument capturing is enabled.