### PR TITLE
Improve stability of some ct tests

### DIFF
--- a/src/xprof_app.erl
+++ b/src/xprof_app.erl
@@ -12,8 +12,12 @@
 %% API
 
 start(_StartType, _StartArgs) ->
-    start_cowboy(),
-    xprof_sup:start_link().
+    case start_cowboy() of
+        {ok, _} ->
+            xprof_sup:start_link();
+        {error, _} = Error ->
+            Error
+    end.
 
 stop(_State) ->
     stop_cowboy(),

--- a/test/xprof_http_e2e_SUITE.erl
+++ b/test/xprof_http_e2e_SUITE.erl
@@ -36,7 +36,7 @@ end_per_suite(_Config) ->
     ok.
 
 init_per_testcase(_TestCase, Config) ->
-    xprof:start(),
+    {ok, _} = xprof:start(),
     Config.
 
 end_per_testcase(_TestCase, _Config) ->

--- a/test/xprof_http_e2e_SUITE.erl
+++ b/test/xprof_http_e2e_SUITE.erl
@@ -73,7 +73,10 @@ get_overflow_status_after_hitting_overload(_Config) ->
     given_traced("dict:new/0"),
 
     %% when
+    %% freeze the tracer process while it receives many trace messages
+    sys:suspend(xprof_tracer),
     dict:new(), dict:new(), dict:new(),
+    sys:resume(xprof_tracer),
     {HTTPCode, JSON} = make_get_request("api/trace_status"),
 
     %% then

--- a/test/xprof_tracing_SUITE.erl
+++ b/test/xprof_tracing_SUITE.erl
@@ -300,11 +300,11 @@ long_call(_Config) ->
 
     %% minimum should be 20 ms with a bit of precision error
     Min = proplists:get_value(min, StatsItems),
-    ?assertMatch({true, _}, {Min < 21*1000, Min}),
+    ?assertMatch({true, _}, {Min < 22*1000, Min}),
 
     %% maximum should be 100 ms with a bit of precision error
     Max = proplists:get_value(max, StatsItems),
-    ?assertMatch({true, _}, {Max > 99*1000, Max}),
+    ?assertMatch({true, _}, {Max > 98*1000, Max}),
 
     %% data capturing also works for too long calls
     {ok, {Id, 50, 1, 1}, [CapturedData]} =


### PR DESCRIPTION
- In case xprof is already running in a separate node fail in
`init_per_testcase` (skipping the test cases) instead of many test
cases failing in a mysterious way.
- overload: freeze tracer module to make sure all messages arrive
  at once
- long call: increase tolerance to hdr histogram's precision error

closes #55