### PR TITLE
Bugfixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@ XProf [![Build Status](https://travis-ci.org/Appliscale/xprof.svg?branch=master)
 =====
 
 *XProf* is a profiler that allows you to track execution time of Elixir / Erlang
-functions. It's also able to capture arguments and results of a function calls
-that lasted longer than given number of milliseconds.
+functions. It's also able to capture arguments and results (return value or
+exception) of function calls that lasted longer than given number of
+milliseconds.
 
 ## Goal
 
@@ -108,8 +109,8 @@ definition) but both can be omitted. In Elixir syntax no `end` keyword should be
 placed at the end of the expression (unlike when defining a function or fun
 object).
 
-The `return_trace` switch is always implicitly on (as that is how `xprof`
-measures duration)
+The `return_trace`/`exception_trace` switches are always implicitly on (as that
+is how `xprof` measures duration)
 
 Let's see some examples to make sense of all this.
 

--- a/priv/app/graph.jsx
+++ b/priv/app/graph.jsx
@@ -86,7 +86,7 @@ export default class Graph extends React.Component {
           // "The position of the ticks will be calculated precisely, so the values on the ticks will not be rounded nicely."
           outer: false,
           format: function(d) {
-            return d3.format(".2s")(d / 100000) + "s";
+            return d3.format(".2s")(d / 1000000) + "s";
           }
         }
       },

--- a/src/xprof_ms.erl
+++ b/src/xprof_ms.erl
@@ -79,7 +79,7 @@ workaround_empty_args_ms(Ms) ->
 
 %% - For the general case when the match-spec body does not contain any message
 %% directive a default message ({message, arity} or {message, '$_'}) is inserted
-%% as the first action of the body as well as enabling return_trace
+%% as the first action of the body as well as enabling exception_trace
 
 fix_ms(MS) ->
     {traverse_ms(MS, _CaptureOff = false),
@@ -92,7 +92,7 @@ traverse_ms(MS, Capture) ->
             true -> '$_'
         end,
     [{Head, Condition,
-      [{return_trace},{message, DefaultMsg}|traverse_ms_c(Body, Capture)]}
+      [{exception_trace},{message, DefaultMsg}|traverse_ms_c(Body, Capture)]}
      || {Head, Condition, Body} <- MS].
 
 %% @doc traverse a match-spec clause

--- a/src/xprof_tracer.erl
+++ b/src/xprof_tracer.erl
@@ -121,12 +121,10 @@ handle_call(_Request, _From, State) ->
 handle_cast(_Msg, State) ->
     {noreply, State}.
 
-handle_info(Msg = {trace_ts, _TracedPid, call, MFA, _Args, _StartTime}, State) ->
-    NewState = check_for_overflow(State),
-    send2pids(MFA, Msg),
-    {noreply, NewState};
-handle_info(Msg = {trace_ts, _TracedPid, return_from, MFA , _Res, _StartTime},
-            State) ->
+handle_info(Msg = {trace_ts, _TracedPid, Tag, MFA, _TraceTerm, _StartTime}, State)
+  when Tag =:= call;
+       Tag =:= return_from;
+       Tag =:= exception_from ->
     NewState = check_for_overflow(State),
     send2pids(MFA, Msg),
     {noreply, NewState};

--- a/src/xprof_tracer_handler.erl
+++ b/src/xprof_tracer_handler.erl
@@ -146,14 +146,16 @@ handle_info({trace_ts, Pid, call, _MFA, Args, StartTime}, State) ->
 
     {Timeout, NewState} = maybe_make_snapshot(State),
     {noreply, NewState, Timeout};
-handle_info({trace_ts, Pid, return_from, _MFA, Ret, EndTime}, State) ->
+handle_info({trace_ts, Pid, Tag, _MFA, RetOrExc, EndTime}, State)
+  when Tag =:= return_from;
+       Tag =:= exception_from ->
 
     NewState = case get_ts_args(Pid) of
                    undefined ->
                        State;
                    {StartTime, Args} ->
                        CallTime = timer:now_diff(EndTime, StartTime),
-                       record_results(Pid, CallTime, Args, Ret, State)
+                       record_results(Pid, CallTime, Args, RetOrExc, State)
                end,
 
     {Timeout, NewState2} = maybe_make_snapshot(NewState),

--- a/src/xprof_tracer_handler.erl
+++ b/src/xprof_tracer_handler.erl
@@ -278,7 +278,9 @@ record_results(Pid, CallTime, Args, Res,
 
     case CaptureSpec of
         {Threshold, Limit}
-          when CallTime > Threshold * 1000 andalso Count =< Limit ->
+          when CallTime > Threshold * 1000 andalso
+               Count =< Limit andalso
+               Args =/= arity ->
             ets:insert(Name, {{args_res, Count},
                               {Pid, CallTime, Args, Res}}),
             %% reached limit - turn off args tracing

--- a/test/xprof_ms_tests.erl
+++ b/test/xprof_ms_tests.erl
@@ -3,8 +3,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(M, xprof_ms).
--define(DEFAULT_MS, {[{'_', [], [{return_trace}, {message, arity}]}],
-                     [{'_', [], [{return_trace}, {message, '$_'}]}]}).
+-define(DEFAULT_MS, {[{'_', [], [{exception_trace}, {message, arity}]}],
+                     [{'_', [], [{exception_trace}, {message, '$_'}]}]}).
 
 tokens_test_() ->
     [?_assertEqual(
@@ -34,8 +34,8 @@ parse_test_() ->
     ].
 
 ensure_dot_test_() ->
-    MSs = {[{['_'],[],[{return_trace},{message,arity},true]}],
-           [{['_'],[],[{return_trace},{message,'$_'},true]}]},
+    MSs = {[{['_'],[],[{exception_trace},{message,arity},true]}],
+           [{['_'],[],[{exception_trace},{message,'$_'},true]}]},
     [?_assertEqual(
         {ok, {{m, f, 1}, MSs}},
         ?M:fun2ms("m:f(_) -> true")),
@@ -49,8 +49,8 @@ ensure_dot_test_() ->
 
 ensure_body_test_() ->
     MS = fun(Args, Guards) ->
-                 {[{Args,Guards,[{return_trace},{message,arity},true]}],
-                  [{Args,Guards,[{return_trace},{message,'$_'},true]}]
+                 {[{Args,Guards,[{exception_trace},{message,arity},true]}],
+                  [{Args,Guards,[{exception_trace},{message,'$_'},true]}]
                  }
          end,
     [?_assertEqual(
@@ -78,8 +78,8 @@ ms_test_() ->
         ?M:fun2ms("m:f(A = {B, _}) -> {A, B}")),
      ?_assertEqual(
         {ok, {{m, f, 0},
-              {[{[],[],[{return_trace},{message,arity},true]}],
-               [{[],[],[{return_trace},{message,'$_'},true]}]}}},
+              {[{[],[],[{exception_trace},{message,arity},true]}],
+               [{[],[],[{exception_trace},{message,'$_'},true]}]}}},
         ?M:fun2ms("m:f() -> true"))
     ].
 
@@ -87,18 +87,18 @@ traverse_ms_test_() ->
     MSs =
     {%% capture args off
       [%% false -> false: no trace
-       {[a,'_'], [], [{return_trace},{message,arity},{message,false}]},
+       {[a,'_'], [], [{exception_trace},{message,arity},{message,false}]},
        %% true -> arity: trace without args
-       {[b,'_'], [], [{return_trace},{message,arity},{message,arity}]},
+       {[b,'_'], [], [{exception_trace},{message,arity},{message,arity}]},
        %% custom msg -> arity: trace without args
-       {['_','$1'], [], [{return_trace},{message,arity},{message,arity}]}],
+       {['_','$1'], [], [{exception_trace},{message,arity},{message,arity}]}],
       %% capture args on
       [%% false -> false: no trace
-       {[a,'_'], [], [{return_trace},{message,'$_'},{message,false}]},
+       {[a,'_'], [], [{exception_trace},{message,'$_'},{message,false}]},
        %% true -> '$_' aka object(): trace with all args
-       {[b,'_'], [], [{return_trace},{message,'$_'},{message,'$_'}]},
+       {[b,'_'], [], [{exception_trace},{message,'$_'},{message,'$_'}]},
        %% custom msg -> custom msg: trace with one arg only
-       {['_','$1'], [], [{return_trace},{message,'$_'},{message,'$1'}]}]},
+       {['_','$1'], [], [{exception_trace},{message,'$_'},{message,'$1'}]}]},
 
     [?_assertEqual(
         {ok, {{m, f, 2}, MSs}},
@@ -140,14 +140,14 @@ fun2ms_elixir_test_() ->
                          {{'Elixir.Mod','fun',0},
                           {[{[], [], _}],
                            [{[],[],
-                             [{return_trace},{message,'$_'},{message,data}]}]}
+                             [{exception_trace},{message,'$_'},{message,data}]}]}
                          }},
                         ?M:fun2ms("Mod.fun() -> message(:data)")),
           ?_assertMatch({ok,
                          {{'Elixir.Mod','fun',0},
                           {[{[], [], _}],
                            [{[],[],
-                             [{return_trace},{message,'$_'},{message,data}]}]}
+                             [{exception_trace},{message,'$_'},{message,data}]}]}
                          }},
                         ?M:fun2ms("Mod.fun -> message(:data)")),
           %% bug in Elixir up to 1.4.2
@@ -161,7 +161,7 @@ fun2ms_elixir_test_() ->
                          {{'Elixir.Mod','fun',2},
                           {[{[data,'$1'], [{'>','$1',1}], _}],
                            [{[data,'$1'], [{'>','$1',1}],
-                             [{return_trace},{message,'$_'},{message,'$1'}]}]}
+                             [{exception_trace},{message,'$_'},{message,'$1'}]}]}
                          }},
                         ?M:fun2ms("Mod.fun(:data, a) when a > 1 -> message(a)"))
          ]},

--- a/test/xprof_tracing_SUITE.erl
+++ b/test/xprof_tracing_SUITE.erl
@@ -119,8 +119,11 @@ monitor_crashing_fun(_Config) ->
     maybe_crash_test_fun(false),
     ct:sleep(2000),
 
-    [Items1|_] = xprof_tracer:data(MFA, Last),
-    ?assertEqual(3, proplists:get_value(count, Items1)),
+    Items = xprof_tracer:data(MFA, Last - 1),
+    %% it is possible that the 3 function calls are spread
+    %% across multiple snapshots
+    ?assertEqual(3, lists:sum([proplists:get_value(count, Item)
+                               || Item <- Items])),
 
     xprof_tracer:trace(pause),
     xprof_tracer:demonitor(MFA),

--- a/test/xprof_tracing_SUITE.erl
+++ b/test/xprof_tracing_SUITE.erl
@@ -10,9 +10,11 @@
 all() ->
     [monitor_many_funs,
      monitor_recursive_fun,
+     monitor_crashing_fun,
      monitor_ms,
      capture_args_res,
      capture_args_ms,
+     capture_exception,
      capture_stop,
      long_call,
      {group, simulate_tracing}].
@@ -105,6 +107,25 @@ dead_proc_tracing(_Config) ->
     ?assertMatch({{spawner, Pid, 1.0}, running},
                  xprof_tracer:trace_status()),
     ok.
+
+monitor_crashing_fun(_Config) ->
+    xprof_tracer:monitor(MFA = {?MODULE, maybe_crash_test_fun, 1}),
+    ok = xprof_tracer:trace(self()),
+
+    Last = get_print_current_time(),
+
+    maybe_crash_test_fun(false),
+    catch maybe_crash_test_fun(true),
+    maybe_crash_test_fun(false),
+    ct:sleep(2000),
+
+    [Items1|_] = xprof_tracer:data(MFA, Last),
+    ?assertEqual(3, proplists:get_value(count, Items1)),
+
+    xprof_tracer:trace(pause),
+    xprof_tracer:demonitor(MFA),
+    ok.
+
 
 monitor_many_funs(_Config) ->
     MFAs = [{code, all_loaded, 0}, {?MODULE, test_fun, 0},
@@ -248,6 +269,26 @@ capture_args_ms(_Config) ->
     xprof_tracer:demonitor(MFA),
     ok.
 
+capture_exception(_Config) ->
+    xprof_tracer:monitor(MFA = {?MODULE, maybe_crash_test_fun, 1}),
+    ok = xprof_tracer:trace(self()),
+
+    %% Start first capture
+    {ok, Id} = xprof_tracer_handler:capture(MFA, 1, 3),
+
+    catch maybe_crash_test_fun(true),
+
+    ct:sleep(10), %% Let trace messages reach the process
+
+    {ok, {Id, 1, 3, 3}, [Item1]} =
+        xprof_tracer_handler:get_captured_data(MFA,0),
+
+    ?assertMatch([_Num, _Pid, _Time, [true], {throw, test_crash}], Item1),
+
+    xprof_tracer:trace(pause),
+    xprof_tracer:demonitor(MFA),
+    ok.
+
 capture_stop(_Config) ->
     xprof_tracer:monitor(MFA = {?MODULE, test_fun, 1}),
     ok = xprof_tracer:trace(self()),
@@ -335,6 +376,12 @@ recursive_test_fun(0) ->
 recursive_test_fun(N) ->
     timer:sleep(10),
     recursive_test_fun(N - 1).
+
+maybe_crash_test_fun(false) ->
+    ok;
+maybe_crash_test_fun(true) ->
+    timer:sleep(10),
+    throw(test_crash).
 
 get_print_current_time() ->
     {MS,S,_} = os:timestamp(),


### PR DESCRIPTION
A few independent bug fixes

* **Fix incorrect time on graph**

Because of a scaling bug 10x higher times were displayed on the graph Y
axis as what was measured (ie. 10ms instead of 1ms)
This had the false user experience as if long-call capturing wouldn't
work sometimes.

* **Fix leaking internal trick in argument capturing**

When long-call capturing is turned on it is possible that the trace
message with the start of the function call was already processed. In
this case only the atom 'arity' is stored instead of the
arguments. Don't show such initial long calls.

* **Trace also on exceptions**

Not doing so had a few bad effects:
- the arguments stored in the procdict of tracer_handler were never
  cleared (as there was no matching return)

- tracer_handler was tricked to believe that the call for the same MFA after
  a crashing call was a recursive call (it tries to only measure the
  outermost calls and the previous call hasn't returned yet). As a
  result after a crash following calls in the same process for the given
  MFA were not measured any more. This is only a problem if the process
  actually caught the exception and continued executing.

Now an exception is treated the same way as a return and it is also
shown when long-calls are captured as a {Class, Exception} tuple.

Future improvements:
- it would be possible to tag and differentiate returns and exceptions
  and display them differently on the GUI
- there could be also an indication of exceptions on the graph (eg a
  vertical red line as an event or a separate exception count graph)