### PR TITLE
Fix elixir test failing on Travis

### DIFF
--- a/test/xprof_elixir_syntax_tests.erl
+++ b/test/xprof_elixir_syntax_tests.erl
@@ -121,10 +121,17 @@ fmt_test_() ->
                        ?M:fmt_exception(error, {badmatch, dummy})),
          ?_assertEqual(<<"** (throw) :dummy">>,
                        ?M:fmt_exception(throw, dummy)),
-         ?_assertEqual(<<"** (exit) exited in: :gen_server.call(:server, :msg)\n    "
-                         "** (EXIT) no process: the process is not alive or "
-                         "there's no process currently associated with the given name, "
-                         "possibly because its application isn't started">>,
+         ?_assertEqual(case xprof_test_lib:is_elixir_version(">= 1.4.0")  of
+                           true ->
+                               %% in version 1.4.0 the exception description was improved
+                               <<"** (exit) exited in: :gen_server.call(:server, :msg)\n    "
+                                 "** (EXIT) no process: the process is not alive or "
+                                 "there's no process currently associated with the given name, "
+                                 "possibly because its application isn't started">>;
+                           false ->
+                               <<"** (exit) exited in: :gen_server.call(:server, :msg)\n    "
+                                 "** (EXIT) no process">>
+                       end,
                        ?M:fmt_exception(exit, {noproc, {gen_server, call, [server, msg]}}))
         ],
     xprof_test_lib:run_elixir_unit_tests(Tests).

--- a/test/xprof_test_lib.erl
+++ b/test/xprof_test_lib.erl
@@ -1,9 +1,19 @@
 -module(xprof_test_lib).
 
--export([run_elixir_unit_tests/1]).
+-export([is_elixir_version/1,
+         run_elixir_unit_tests/1]).
 
 -define(EUNIT_NOAUTO, true).
 -include_lib("eunit/include/eunit.hrl").
+
+-spec is_elixir_version(string()) -> boolean().
+is_elixir_version(Requirement) ->
+    try
+        ElixirVsn = 'Elixir.System':version(),
+        'Elixir.Version':'match?'(ElixirVsn, list_to_binary(Requirement))
+    catch _:_ ->
+            false
+    end.
 
 run_elixir_unit_tests(Tests) ->
     case os:find_executable("elixir") of


### PR DESCRIPTION
The erlang image on Travis started to include an old default elixir
version (1.3.2). Since that version the format of one exception changed.