### PR TITLE
Build docs and run dialyzer on Travis (only with newest erlang)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ branches:
     only:
         - master
 otp_release:
-    - 19.2
+    - 20.0
+    - 19.3
     - 18.3
     - 17.5
     - R16B03-1
@@ -18,6 +19,7 @@ install:
 script:
     - make test
     - make test_front_end
+    - if [ $TRAVIS_OTP_RELEASE = "20.0" ]; then make doc dialyzer; fi
 after_success:
     - ./rebar3 cover
     - if [ $TRAVIS_OTP_RELEASE = "18.3" ]; then ./rebar3 coveralls send; fi

--- a/Makefile
+++ b/Makefile
@@ -26,5 +26,10 @@ webpack_autoreload: npm
 test: compile
 	./rebar3 do eunit -c, ct -c, cover
 
+doc:
+	./rebar3 edoc
 
-.PHONY=compile dev npm bootstrap_front_end check_front_end test_front_end webpack webpack_autoreload test
+dialyzer:
+	./rebar3 dialyzer
+
+.PHONY: compile dev npm bootstrap_front_end check_front_end test_front_end webpack webpack_autoreload test doc dialyzer


### PR DESCRIPTION
Edoc docs are only built in preparation for the upcoming, documented
`xprof_core` erlang API.