### PR TITLE
Show graphs in latest-on-top order

### DIFF
--- a/src/xprof_tracer.erl
+++ b/src/xprof_tracer.erl
@@ -97,9 +97,9 @@ handle_call({monitor, MFASpec, Query}, _From, State) ->
         undefined ->
             {ok, Pid} = supervisor:start_child(xprof_tracer_handler_sup, [MFASpec]),
             put_pid(MFAId, Pid),
-            %% funs stored in the order of start monitoring
+            %% funs stored in reversed order of start monitoring
             NState = setup_trace_all_if_initialized(State),
-            {reply, ok, NState#state{funs = State#state.funs ++ [{MFAId, Query}]}}
+            {reply, ok, NState#state{funs = [{MFAId, Query}|State#state.funs]}}
     end;
 handle_call({demonitor, MFA}, _From, State) ->
     xprof_tracer_handler:trace_mfa_off(MFA),

--- a/test/xprof_tracing_SUITE.erl
+++ b/test/xprof_tracing_SUITE.erl
@@ -146,7 +146,8 @@ monitor_many_funs(_Config) ->
 
     %% strip formatted queries
     AllMonitored = [MFA || {MFA, _Query} <- xprof_tracer:all_monitored()],
-    ?assertEqual(MFAs, AllMonitored),
+    %% MFAs should be listed in reversed insertion order (last first)
+    ?assertEqual(lists:reverse(MFAs), AllMonitored),
 
     ct:log("Stop monitoring all 5 funs"),
     [xprof_tracer:demonitor(MFA) || MFA <- MFAs],


### PR DESCRIPTION
Apparently it used to be intentional in the BE to store newest mfa
last. But prepending to the list is easier and people requested this
order too so let's reverse in the BE.

closes #87 

Sorry, after all it looks to be wee bit better to change order in the backend instead of reversing in the backend and then on the frontend too. (Then documenting the erlang API returns the same order as shown on the GUI.) I just bumped into this when trying a naive optimisation to compare list of functions (and they did not match because of the order)
https://github.com/gomoripeti/xprof/commit/8345fd2085e4f01b2b12e80ab9844820f25ff914#diff-95e43eca9e872652eb8269a81d0b2d16R53