### PR TITLE
Fix edge case in match-spec rewrite

### DIFF
--- a/apps/xprof_core/src/xprof_core_ms.erl
+++ b/apps/xprof_core/src/xprof_core_ms.erl
@@ -101,7 +101,10 @@ traverse_ms_c([{message, true}|T], false) ->
 traverse_ms_c([{message, true}|T], true) ->
     [{message, '$_'}|traverse_ms_c(T, true)];
 traverse_ms_c([{message, Other}|T], false) when Other =/= false ->
-    [{message, arity}|traverse_ms_c(T, false)];
+    %% In case `Other' evaluates to `false', return `false' (disable sending a
+    %% trace message). Otherwise return `arity'.
+    %% message( (Other =/= false ) andalso 'arity' )
+    [{message, {'andalso', {'=/=', Other, false}, arity}}|traverse_ms_c(T, false)];
 traverse_ms_c([H|T], C) ->
     [traverse_ms_c(H, C)|traverse_ms_c(T, C)];
 traverse_ms_c(Tuple, C) when is_tuple(Tuple) ->


### PR DESCRIPTION
We modify the match-spec so that if we don't capture arguments no unused
term is included in the trace message. However some tricky
folks (eg. me) include logic within the `message()` action-function to
conditionally mute tracing. This was just replaced all together.

Now this is fixed by not only checking if the value withing `message()`
is literarily `false` but also whether it evaluates to `false` (at
run-time)