### PR TITLE
Move plugins to profiles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,7 @@ doc:
 dialyzer:
 	./rebar3 dialyzer
 
+publish:
+	./rebar3 as publish hex publish
+
 .PHONY: compile dev npm bootstrap_front_end check_front_end test_front_end webpack webpack_autoreload test doc dialyzer

--- a/rebar.config
+++ b/rebar.config
@@ -14,10 +14,14 @@
 
 {profiles,
  [{test,
-   [{deps, [ {cth_readable, "1.2.1"} ]}
+   [{deps, [ {cth_readable, "1.2.1"} ]},
+    {plugins, [ {coveralls, "1.3.0"} ]}
    ]},
   {dev,
    [{deps, [ {sync, "0.1.3"} ]}
+   ]},
+  {publish,
+   [{plugins, [ rebar3_hex ]}
    ]}
  ]}.
 
@@ -27,7 +31,9 @@
 {coveralls_coverdata, [ "_build/test/cover/eunit.coverdata", "_build/test/cover/ct.coverdata" ]}.
 {coveralls_service_name, "travis-ci"}.
 
-{plugins, [
-  rebar3_hex,
-  {coveralls, "1.3.0"}
-]}.
+%% customized_hdr_histogram defines rebar_hex plugin
+%% but that is only needed for package publishing
+%% (and we don't want to publish hdr_histogram packages)
+{overrides,
+ [{override, customized_hdr_histogram, [{plugins, []}]}
+ ]}.


### PR DESCRIPTION
Move hex plugin to its own, new publish profile. It is only used for
creating hex pacakges but not for fetching them. It uses maps and cannot
be compiled on R16B. This is not an issue just creates noise in the
output.

While at it move coveralls plugin to the test profile as it is only
used in test commands.

(inspired by recently announced [steady_vector](https://github.com/g-andrade/steady_vector/blob/master/Makefile#L49) library)