### PR TITLE
Stop graphs when tracing is stopped

### DIFF
--- a/apps/xprof_gui/priv/src/actions/CollectingActions.js
+++ b/apps/xprof_gui/priv/src/actions/CollectingActions.js
@@ -52,7 +52,8 @@ export const getFunctionsData = () => async (dispatch, getState) => {
   const state = getState();
   const mfas = getMfas(state);
   const data = getData(state);
-  const nextData = await determineNextData(mfas, data);
+  const running = state.status.status === 'running';
+  const nextData = running && await determineNextData(mfas, data);
 
   if (!isEmpty(nextData)) {
     dispatch(updateData({ ...data, ...nextData }));
@@ -63,7 +64,9 @@ export const getFunctionsCalls = () => async (dispatch, getState) => {
   const state = getState();
   const mfas = getMfas(state);
   const calls = getCalls(state);
-  const nextCalls = await determineNextCalls(dispatch, state, mfas, calls);
+  const running = state.status.status === 'running';
+  const nextCalls = running
+  && await determineNextCalls(dispatch, state, mfas, calls);
 
   if (!isEmpty(nextCalls)) {
     dispatch(updateCalls({ ...calls, ...nextCalls }));

--- a/apps/xprof_gui/priv/src/components/functions/Functions.jsx
+++ b/apps/xprof_gui/priv/src/components/functions/Functions.jsx
@@ -6,6 +6,7 @@ import { FUNCTIONS_INTERVAL } from '../../constants';
 const propTypes = {
   getMonitoredFunctions: PropTypes.func.isRequired,
   mfas: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any)).isRequired,
+  running: PropTypes.bool.isRequired,
 };
 
 class Functions extends React.Component {
@@ -24,12 +25,12 @@ class Functions extends React.Component {
   }
 
   render() {
-    const { mfas } = this.props;
+    const { mfas, running } = this.props;
     return (
       <div>
         {mfas.map((mfa, index) => (
           <div key={mfa[3]}>
-            <MonitoringContainer mfa={mfa} />
+            <MonitoringContainer mfa={mfa} running={running} />
             <TracingContainer mfa={mfa} />
             {index < mfas.length - 1 ? (
               <hr className="function-separator" />

--- a/apps/xprof_gui/priv/src/components/monitoring/Monitoring/Monitoring.jsx
+++ b/apps/xprof_gui/priv/src/components/monitoring/Monitoring/Monitoring.jsx
@@ -23,13 +23,29 @@ const propTypes = {
   expandGraphPanel: PropTypes.func.isRequired,
   shrinkGraphPanel: PropTypes.func.isRequired,
   calleeClick: PropTypes.func.isRequired,
+  running: PropTypes.bool.isRequired,
 };
 
 class Monitoring extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      snapshot: null,
+    };
+  }
+
   componentWillMount() {
-    const { getFunctionsData } = this.props;
+    const { getFunctionsData, data } = this.props;
     getFunctionsData();
     this.dataInterval = setInterval(getFunctionsData, DATA_INTERVAL);
+    this.setState({ snapshot: data });
+  }
+
+  componentWillReceiveProps(nextProps) {
+    const { running, data } = this.props;
+    if (nextProps.running !== running && running === true) {
+      this.setState({ snapshot: data });
+    }
   }
 
   componentWillUnmount() {
@@ -50,13 +66,15 @@ class Monitoring extends React.Component {
       expandGraphPanel,
       shrinkGraphPanel,
       calleeClick,
+      running,
     } = this.props;
+    const { snapshot } = this.state;
     return (
       <div>
         <GraphPanel
           key={mfa[3]}
           mfa={mfa}
-          dps={data}
+          dps={running ? data : snapshot}
           stopMonitoringFunction={stopMonitoringFunction}
           callees={callees}
           calleesVisibility={calleesVisibility}

--- a/apps/xprof_gui/priv/src/containers/FunctionsContainer/FunctionsContainer.jsx
+++ b/apps/xprof_gui/priv/src/containers/FunctionsContainer/FunctionsContainer.jsx
@@ -8,6 +8,7 @@ const FunctionsContainer = props => <Functions {...props} />;
 
 const mapStateToProps = state => ({
   mfas: getMfas(state),
+  running: state.status.status === 'running',
 });
 
 const mapDispatchToProps = {

--- a/apps/xprof_gui/priv/src/containers/MonitoringContainer/MonitoringContainer.jsx
+++ b/apps/xprof_gui/priv/src/containers/MonitoringContainer/MonitoringContainer.jsx
@@ -26,6 +26,7 @@ const mapStateToProps = (state, ownProps) => ({
   callees: getFunctionCallees(state, ownProps.mfa[3]),
   calleesVisibility: getFunctionCalleesVisibility(state, ownProps.mfa[3]),
   panelVisibility: getFunctionGraphVisibility(state, ownProps.mfa[3]),
+  running: ownProps.running,
 });
 
 const mapDispatchToProps = {


### PR DESCRIPTION
This will also stop polling the backend for new data (there won't be any
new data anyway)

(Work by Kuba, rebased onto `release_2.0`)