### PR TITLE
Serve front-end files from build-dev dir if it exists

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ cover/
 _build/
 
 apps/xprof_gui/priv/build/*.js.map
+apps/xprof_gui/priv/build-dev/
 apps/xprof_gui/priv/bower_components/
 apps/xprof_gui/priv/node_modules/
 

--- a/apps/xprof_gui/priv/config/paths.js
+++ b/apps/xprof_gui/priv/config/paths.js
@@ -37,6 +37,7 @@ function getServedPath(appPackageJson) {
 module.exports = {
   dotenv: resolveApp('.env'),
   appBuild: resolveApp('build'),
+  appDevBuild: resolveApp('build-dev'),
   appPublic: resolveApp('public'),
   appHtml: resolveApp('public/index.html'),
   appIndexJs: resolveApp('src/index.js'),

--- a/apps/xprof_gui/priv/config/webpack.config.dev.js
+++ b/apps/xprof_gui/priv/config/webpack.config.dev.js
@@ -55,7 +55,7 @@ module.exports = {
   ],
   output: {
     // Next line is not used in dev but WebpackDevServer crashes without it:
-    path: paths.appBuild,
+    path: paths.appDevBuild,
     // Add /* filename */ comments to generated require()s in the output.
     pathinfo: true,
     // This does not produce a real file. It's just the virtual path that is

--- a/apps/xprof_gui/src/xprof_gui_app.erl
+++ b/apps/xprof_gui/src/xprof_gui_app.erl
@@ -39,12 +39,26 @@ start_cowboy() ->
     ?HANDLER_MOD:start_listener(?LISTENER, Port, Dispatch).
 
 cowboy_dispatch(Mod) ->
+    StaticDir = get_static_dir(),
+    Index = filename:join(StaticDir, "index.html"),
     Routes =
         [{'_', [{"/api/:what", Mod, []},
-                {"/", cowboy_static, {priv_file, ?APP, "build/index.html"}},
-                {"/[...]", cowboy_static, {priv_dir, ?APP, "build"}}
+                {"/", cowboy_static, {priv_file, ?APP, Index}},
+                {"/[...]", cowboy_static, {priv_dir, ?APP, StaticDir}}
                ]}],
     cowboy_router:compile(Routes).
+
+%% Only for development
+%% If `build-dev' directory exists serve static assets from there.
+%% It should not be present when XProf is used as a lib within another
+%% application.
+get_static_dir() ->
+    case filelib:is_dir(filename:join(code:priv_dir(?APP), "build-dev")) of
+        true ->
+            "build-dev";
+        false ->
+            "build"
+    end.
 
 stop_cowboy() ->
     cowboy:stop_listener(?LISTENER).


### PR DESCRIPTION
Only for development. It should not be present when XProf is used as a
lib within another application.

closes #138 