### PR TITLE
Add record support in xprof flavoured match-spec funs 

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Key                    | Default        | Description
 `max_duration`         | 30000          | The largest duration value in ms. In case a call takes even longer, this maximum value is stored instead.
 `ignore_recursion`     | true           | Whether to only measure the outermost call to a recursive function or not (ie. measure all calls).
 `mode`                 | <autodetected> | Syntax mode (`erlang` or `elixir`)
+`load_records`         | []             | List of modules from which to load record definitions at startup.
 
 ## XProf flavoured match-spec funs
 
@@ -194,6 +195,17 @@ multiple clauses. (Notice there is no closing `end` keyword)
 ```elixir
 Registry.dispatch(MyApp.Registry, "topic1", _) -> nil; (MyApp.Registry, "topic2", _) -> nil
 ```
+
+## Erlang records
+
+Elrang record syntax is supported in the queries and works similar to the Erlang
+shell. XProf keeps a single global list of loaded record definitions. Record
+definitions can be loaded at startup time from modules listed in app env
+`load_records` or at runtime calling `xprof_core:rr(Module)` (see documentation
+of `xprof_core` for more details). The record definitions are extracted from
+debug_info of the beam files belonging to the loaded modules. As the list is
+global there can be only one record with the same name loaded at a time and
+records loaded later might override previously loaded ones.
 
 ## Contributing
 

--- a/apps/xprof_core/src/xprof_core.erl
+++ b/apps/xprof_core/src/xprof_core.erl
@@ -22,6 +22,13 @@
          get_captured_data_pp/2,
          get_captured_data/2,
 
+         %% Records
+
+         rr/1,
+         rf/0,
+         rf/1,
+         rl/0,
+
          %% Syntax mode
          set_mode/1,
          get_mode/0
@@ -199,6 +206,35 @@ format_result({exception_from, {Class, Reason}}, ModeCb) ->
                 Result :: term()}.
 get_captured_data(MFA, Offset) ->
     xprof_core_trace_handler:get_captured_data(MFA, Offset).
+
+%%
+%% Records
+%%
+
+%% @doc Load record definitions from module.
+%% (similar to shell command `rr/1')
+-spec rr(module()) -> [RecName :: atom()].
+rr(Mod) ->
+    xprof_core_records:load_records(Mod).
+
+%% @doc Remove all record definitions.
+%% (similar to shell command ```rf('_')''')
+-spec rf() -> ok.
+rf() ->
+    xprof_core_records:forget_records().
+
+%% @doc Remove selected record definitions. RecNames is a record name or a
+%% list of record names. To remove all record definitions, use '_'.
+%% (similar to shell command `rf/1')
+-spec rf(atom() | [atom()]) -> ok.
+rf(RecNameOrNames) ->
+    xprof_core_records:forget_records(RecNameOrNames).
+
+%% @doc Return all stored record definitions.
+%% (Similar to shell command `rl()')
+-spec rl() -> [tuple()].
+rl() ->
+    xprof_core_records:get_record_defs().
 
 %%
 %% Syntax mode

--- a/apps/xprof_core/src/xprof_core_records.erl
+++ b/apps/xprof_core/src/xprof_core_records.erl
@@ -1,0 +1,117 @@
+%%% @doc Server to store loaded record definitions.
+-module(xprof_core_records).
+
+-export([start_link/0,
+         load_records/1,
+         forget_records/0,
+         forget_records/1,
+         get_record_defs/0
+        ]).
+
+%% gen_server callbacks
+
+-export([init/1,
+         handle_call/3,
+         handle_cast/2,
+         handle_info/2,
+         terminate/2,
+         code_change/3]).
+
+-define(TABLE, ?MODULE).
+
+-record(state, {}).
+
+%% @doc Start record store.
+-spec start_link() -> {ok, pid()}.
+start_link() ->
+    gen_server:start_link({local, ?MODULE}, ?MODULE, [], []).
+
+%% @doc Load record definitions from module.
+%% (similar to shell command `rr/1')
+-spec load_records(module()) -> [RecName :: atom()].
+load_records(Mod) when is_atom(Mod) ->
+    gen_server:call(?MODULE, {load_records, Mod}).
+
+%% @doc Remove all record definitions.
+%% (similar to shell command ```rf('_')''')
+-spec forget_records() -> ok.
+forget_records() ->
+    gen_server:call(?MODULE, forget_records).
+
+%% @doc Remove selected record definitions. RecNames is a record name or a
+%% list of record names. To remove all record definitions, use '_'.
+%% (similar to shell command `rf/1')
+-spec forget_records(atom() | [atom()]) -> ok.
+forget_records('_') ->
+    forget_records();
+forget_records(RecName) when is_atom(RecName) ->
+    forget_records([RecName]);
+forget_records(RecNames) when is_list(RecNames) ->
+    gen_server:call(?MODULE, {forget_records, RecNames}).
+
+%% @doc Return all stored record definitions.
+%% (Similar to shell command `rl()')
+-spec get_record_defs() -> [tuple()].
+get_record_defs() ->
+    try
+        ets:select(?TABLE, [{{'_', '$1'}, [], ['$1']}])
+    catch
+        error:badarg ->
+            %% table does not exist for some reason
+            []
+    end.
+
+%% gen_server callbacks
+
+init([]) ->
+    ets:new(?TABLE, [set, protected, named_table, {read_concurrency, true}]),
+    Mods = application:get_env(xprof, load_records, []),
+    RecNames = lists:flatmap(fun get_and_store_record_defs/1, Mods),
+    lager:info("Loaded records: ~p", [RecNames]),
+    {ok, #state{}}.
+
+handle_call({load_records, Mod}, _From, State) ->
+    RecNames = get_and_store_record_defs(Mod),
+    {reply, RecNames, State};
+handle_call(forget_records, _From, State) ->
+    ets:delete_all_objects(?TABLE),
+    {reply, ok, State};
+handle_call({forget_records, RecNames}, _From, State) ->
+    [ets:delete(?TABLE, RecName) || RecName <- RecNames],
+    {reply, ok, State};
+handle_call(_Request, _From, State) ->
+    {reply, ignored, State}.
+
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+
+%% Internal functions
+
+get_and_store_record_defs(Mod) ->
+    Entries = get_record_defs(Mod),
+    ets:insert(?TABLE, Entries),
+    [RecName || {RecName, _} <- Entries].
+
+get_record_defs(Mod) ->
+    case code:get_object_code(Mod) of
+        {_Mod, Bin, _Filename} ->
+            case beam_lib:chunks(Bin, [abstract_code]) of
+                {ok, {_Mod, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
+                    Defs =
+                        [{RecName, RecDef} || {attribute, _Anno, record, {RecName, _Fields}} = RecDef <- Forms],
+                    Defs;
+                _Error ->
+                    []
+            end;
+        error ->
+            []
+    end.

--- a/apps/xprof_core/test/xprof_core_records_tests.erl
+++ b/apps/xprof_core/test/xprof_core_records_tests.erl
@@ -1,0 +1,39 @@
+-module(xprof_core_records_tests).
+
+-export([test_fun/1]).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, xprof_core_records).
+
+-record(r1, {f1}).
+-record(r2, {f2 = default}).
+
+smoke_test_() ->
+    {setup,
+     fun() ->
+             {ok, Pid} = ?M:start_link(),
+             Pid
+     end,
+     fun(Pid) ->
+             unlink(Pid),
+             exit(Pid, kill)
+     end,
+     [?_assertEqual([], ?M:get_record_defs()),
+      ?_assertEqual([r1, r2], ?M:load_records(?MODULE)),
+      ?_assertMatch([{attribute, _, record,
+                      {r1,[{record_field, _, {atom, _,f1}}]}},
+                     {attribute, _, record,
+                      {r2,[{record_field, _, {atom, _,f2}, {atom, _, default}}]}}],
+                    lists:sort(?M:get_record_defs())),
+      ?_assertEqual(ok, ?M:forget_records(r2)),
+      ?_assertMatch([{attribute, _, record,
+                      {r1,[{record_field, _, {atom, _,f1}}]}}],
+                    lists:sort(?M:get_record_defs())),
+      ?_assertEqual(ok, ?M:forget_records('_')),
+      ?_assertEqual([], ?M:get_record_defs())      
+     ]}.
+
+%% only to silence compilation warning about unused records
+test_fun(#r1{}) ->
+    #r2{}.


### PR DESCRIPTION
Record definitions can be loaded at startup time from modules listed in
app env `load_records` or at runtime similar to how the Erlang shell works.

The record definitions are extracted from debug_info of the beam files
belonging to the loaded modules.

There can be only one record with the same name loaded at a time and
records loaded later might override previously loaded ones.