### PR TITLE
Support typed records

### DIFF
--- a/apps/xprof_core/src/xprof_core_ms.erl
+++ b/apps/xprof_core/src/xprof_core_ms.erl
@@ -65,7 +65,7 @@ ms_transform(Clauses, RecDefs) ->
     Result = compile:forms(
                wrap_forms(wrap_args(Clauses), RecDefs),
                [{parse_transform, ms_transform},
-                export_all, binary, 'P', return_errors]),
+                export_all, binary, dpp, return_errors]),
     case Result of
         {ok, [], Forms} ->
             unwrap_forms(Forms);

--- a/apps/xprof_core/test/xprof_core_ms_tests.erl
+++ b/apps/xprof_core/test/xprof_core_ms_tests.erl
@@ -10,7 +10,8 @@
                      [{'_', [], [{exception_trace}, {message, '$_'}]}]}).
 
 %% for testing record syntax in match spec funs
--record(rec, {f1, f2}).
+-type t() :: integer().
+-record(rec, {f1 :: t(), f2 :: xprof_core:mode()}).
 
 tokens_test_() ->
     [?_assertEqual(


### PR DESCRIPTION
We use `compile:forms` to convert a fun to a match-spec using the
`ms_transorm` parse-transform. To also recognise records the definitions
are fetched from the source module. However the definitions might
contain typed fields and local user type definitions are not fetched.

The `P` option of the compiler also runs the linter after module
tranformation which complains about an undefined type. Instead use the
`dpp` compiler option which solely runs the tranformation.