### PR TITLE
Pretty print records in captured args/return value

### DIFF
--- a/apps/xprof_core/src/xprof_core_erlang_syntax.erl
+++ b/apps/xprof_core/src/xprof_core_erlang_syntax.erl
@@ -121,14 +121,18 @@ fmt_fun_and_arity(Fun, Arity) ->
 fmt_exception(Class, Reason) ->
     Stacktrace = [],
     SkipFun = fun(_M, _F, _A) -> false end,
-    PrettyFun = fun(Term, _Indent) -> io_lib:format("~tp", [Term]) end,
+    PrettyFun = fun(Term, _Indent) -> do_fmt_term(Term) end,
     Encoding = unicode,
     unicode:characters_to_binary(
       ["** "|?ERL_ERROR_MOD:format_exception(1, Class, Reason, Stacktrace,
                                              SkipFun, PrettyFun, Encoding)]).
 
 fmt_term(Term) ->
-    fmt("~tp", [Term]).
+    unicode:characters_to_binary(do_fmt_term(Term)).
+
+do_fmt_term(Term) ->
+    io_lib_pretty:print(
+      Term, [{record_print_fun, xprof_core_records:record_print_fun()}]).
 
 fmt(Fmt, Args) ->
     unicode:characters_to_binary(io_lib:format(Fmt, Args)).

--- a/apps/xprof_core/src/xprof_core_erlang_syntax.erl
+++ b/apps/xprof_core/src/xprof_core_erlang_syntax.erl
@@ -15,6 +15,17 @@
          fmt_exception/2,
          fmt_term/1]).
 
+%% in OTP 21 `format_exception/7' was moved from `lib' module to `erl_error'
+-ifdef(OTP_RELEASE).
+-if(?OTP_RELEASE >= 21).
+%% in OTP 21 or hifher
+-define(ERL_ERROR_MOD, erl_error).
+-endif.
+-else.
+%% in OTP 20 or lower
+-define(ERL_ERROR_MOD, lib).
+-endif.
+
 %% @doc Parse a query string that represents either a module-function-arity
 %% or an xprof-flavoured match-spec fun in Erlang syntax.
 %% In the later case the last element of the tuple is the abstract syntax tree
@@ -113,8 +124,8 @@ fmt_exception(Class, Reason) ->
     PrettyFun = fun(Term, _Indent) -> io_lib:format("~tp", [Term]) end,
     Encoding = unicode,
     unicode:characters_to_binary(
-      ["** "|lib:format_exception(1, Class, Reason, Stacktrace,
-                                  SkipFun, PrettyFun, Encoding)]).
+      ["** "|?ERL_ERROR_MOD:format_exception(1, Class, Reason, Stacktrace,
+                                             SkipFun, PrettyFun, Encoding)]).
 
 fmt_term(Term) ->
     fmt("~tp", [Term]).

--- a/apps/xprof_core/test/xprof_core_erlang_syntax_tests.erl
+++ b/apps/xprof_core/test/xprof_core_erlang_syntax_tests.erl
@@ -3,6 +3,8 @@
 -include_lib("eunit/include/eunit.hrl").
 
 -define(M, xprof_core_erlang_syntax).
+%% utf-8 non-breaking space
+-define(NBSP, 194, 160).
 
 %% for testing record syntax pretty-printing
 -record(rec, {f1, f2 :: xprof_core:mode()}).
@@ -19,14 +21,14 @@ fmt_test_() ->
              unlink(Pid),
              exit(Pid, kill)
      end,
-     [?_assertEqual(<<"[1,2,#rec{f1 = 1,f2 = erlang}]">>,
+     [?_assertEqual(<<"[1, 2, #rec{ f1", ?NBSP, "= 1, f2", ?NBSP, "= erlang}]">>,
                     ?M:fmt_term([1, 2, #rec{f1 = 1, f2 = erlang}])),
       ?_assertEqual(<<"** exception error: no match of right hand side value dummy">>,
                     ?M:fmt_exception(error, {badmatch, dummy})),
       ?_assertEqual(<<"** exception throw: dummy">>,
                     ?M:fmt_exception(throw, dummy)),
-      ?_assertEqual(<<"** exception throw: [1,2,#rec{f1 = 1,f2 = erlang}]">>,
+      ?_assertEqual(<<"** exception throw: [1, 2, #rec{ f1", ?NBSP, "= 1, f2", ?NBSP, "= erlang}]">>,
                     ?M:fmt_exception(throw, [1, 2, #rec{f1 = 1, f2 = erlang}])),
-      ?_assertEqual(<<"** exception exit: {noproc,{gen_server,call,[server,msg]}}">>,
+      ?_assertEqual(<<"** exception exit: {noproc, {gen_server, call, [server, msg]}}">>,
                     ?M:fmt_exception(exit, {noproc, {gen_server, call, [server, msg]}}))
      ]}.

--- a/apps/xprof_core/test/xprof_core_erlang_syntax_tests.erl
+++ b/apps/xprof_core/test/xprof_core_erlang_syntax_tests.erl
@@ -1,0 +1,32 @@
+-module(xprof_core_erlang_syntax_tests).
+
+-include_lib("eunit/include/eunit.hrl").
+
+-define(M, xprof_core_erlang_syntax).
+
+%% for testing record syntax pretty-printing
+-record(rec, {f1, f2 :: xprof_core:mode()}).
+
+fmt_test_() ->
+    {setup,
+     fun() ->
+             ok = application:set_env(xprof, load_records, [?MODULE]),
+             {ok, Pid} = xprof_core_records:start_link(),
+             Pid
+     end,
+     fun(Pid) ->
+             application:unset_env(xprof, load_records),
+             unlink(Pid),
+             exit(Pid, kill)
+     end,
+     [?_assertEqual(<<"[1,2,#rec{f1 = 1,f2 = erlang}]">>,
+                    ?M:fmt_term([1, 2, #rec{f1 = 1, f2 = erlang}])),
+      ?_assertEqual(<<"** exception error: no match of right hand side value dummy">>,
+                    ?M:fmt_exception(error, {badmatch, dummy})),
+      ?_assertEqual(<<"** exception throw: dummy">>,
+                    ?M:fmt_exception(throw, dummy)),
+      ?_assertEqual(<<"** exception throw: [1,2,#rec{f1 = 1,f2 = erlang}]">>,
+                    ?M:fmt_exception(throw, [1, 2, #rec{f1 = 1, f2 = erlang}])),
+      ?_assertEqual(<<"** exception exit: {noproc,{gen_server,call,[server,msg]}}">>,
+                    ?M:fmt_exception(exit, {noproc, {gen_server, call, [server, msg]}}))
+     ]}.

--- a/apps/xprof_gui/test/xprof_http_e2e_SUITE.erl
+++ b/apps/xprof_gui/test/xprof_http_e2e_SUITE.erl
@@ -3,6 +3,8 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("eunit/include/eunit.hrl").
 
+-define(TEST_PORT, 7891).
+
 %% CT callbacks
 -export([all/0,
          groups/0,
@@ -118,6 +120,8 @@ init_per_testcase(TestCase, Config) ->
         _ ->
             given_overload_queue_limit(1000)
     end,
+    %% use a different port for tests than the default one
+    application:set_env(xprof_gui, port, ?TEST_PORT),
     {ok, StartedApps} = xprof:start(),
     [{started_apps, StartedApps}|Config].
 
@@ -410,7 +414,9 @@ make_get_request(Path) ->
 
 make_get_request(Path, Params) ->
     EncodedParams = proplist_to_query_string(Params),
-    URL = "http://127.0.0.1:7890/" ++ Path ++ "?" ++  EncodedParams,
+    URL =
+        "http://127.0.0.1:" ++ integer_to_list(?TEST_PORT) ++
+        "/" ++ Path ++ "?" ++  EncodedParams,
     {ok, {{_Ver, HTTPCode, _Reason}, _Headers, Body}} = httpc:request(URL),
     {HTTPCode, decode_json(Body)}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,7 +1,8 @@
 {ct_opts, [{ct_hooks, [cth_readable_failonly, cth_readable_shell]}]}.
 
 {edoc_opts, [{sort_functions, false},
-             {pretty_printer, erl_pp}
+             {pretty_printer, erl_pp},
+             {preprocess, true}
             ]}.
 
 {cover_excl_mods, [test_module]}.


### PR DESCRIPTION
(Best to review commit-by-commit. I'm not sure if the last commit (line-breaks) is a good idea, feels a bit like over-engineering.)

How to find out how to pretty-print records:
- the `rp(Term)` function in the shell pretty-prints a term with record syntax included
- `rp` is implemented in `shell.erl` (https://github.com/erlang/otp/blob/master/lib/stdlib/src/shell.erl#L1011) calling `shell:pp/4`
- `pp/4` uses `io_lib_pretty:print/2` with a record_print_fun (https://github.com/erlang/otp/blob/master/lib/stdlib/src/shell.erl#L1410)
-  record_pretty_fun should be a fun that receives the record name and number of fields and returns the list of the names of the fields. This is done in the shell using the `RT` record table (which is initialised here: https://github.com/erlang/otp/blob/master/lib/stdlib/src/shell.erl#L1143). `xprof_core_records` ets table has the same content (https://github.com/Appliscale/xprof/blob/release_2.0/apps/xprof_core/src/xprof_core_records.erl#L104)