### PR TITLE
Don't crash the rest handler if xprof_core call fails 

### DIFF
--- a/apps/xprof_core/test/xprof_tracing_SUITE.erl
+++ b/apps/xprof_core/test/xprof_tracing_SUITE.erl
@@ -426,14 +426,6 @@ long_call(_Config) ->
     %% both calls should be recorded
     ?assertEqual(2, proplists:get_value(count, StatsItems)),
 
-    %% minimum should be 20 ms with a bit of precision error
-    Min = proplists:get_value(min, StatsItems),
-    ?assertMatch({true, _}, {Min < 22*1000, Min}),
-
-    %% maximum should be 100 ms with a bit of precision error
-    Max = proplists:get_value(max, StatsItems),
-    ?assertMatch({true, _}, {Max > 98*1000, Max}),
-
     %% data capturing also works for too long calls
     {ok, {Id, 50, 1, false}, [CapturedData]} =
         xprof_core:get_captured_data(MFA, 0),
@@ -445,6 +437,18 @@ long_call(_Config) ->
     xprof_core:demonitor(MFA),
 
     application:unset_env(xprof, max_duration),
+
+    %% check times as a last thing because they fail sometimes with a big
+    %% precision error
+
+    %% minimum should be 20 ms with a bit of precision error
+    Min = proplists:get_value(min, StatsItems),
+    ?assertMatch({true, _}, {Min < 22*1000, Min}),
+
+    %% maximum should be 100 ms with a bit of precision error
+    Max = proplists:get_value(max, StatsItems),
+    ?assertMatch({true, _}, {Max > 98*1000, Max}),
+
     ok.
 
 %% Helpers

--- a/apps/xprof_gui/src/xprof_gui_rest.erl
+++ b/apps/xprof_gui/src/xprof_gui_rest.erl
@@ -232,9 +232,15 @@
   -> StatusCode | {StatusCode, Body}
          when StatusCode :: integer(),
               Body :: binary().
+handle_req(What, Params) ->
+    try do_handle_req(What, Params)
+    catch C:E ->
+            lager:error("Error handling REST API request \"~s\" ~p ~p:~p",
+                        [What, Params, C, E]),
+            500
+    end.
 
-%% @doc
-handle_req(<<"funs">>, Params) ->
+do_handle_req(<<"funs">>, Params) ->
     Query = get_query(Params),
 
     {CommonPrefix, Funs} = xprof_core:expand_query(Query),
@@ -247,13 +253,13 @@ handle_req(<<"funs">>, Params) ->
 
     {200, Json};
 
-handle_req(<<"get_callees">>, Req) ->
+do_handle_req(<<"get_callees">>, Req) ->
     MFA = get_mfa(Req),
     Callees = xprof_core:get_called_funs_pp(MFA),
     Json = jsone:encode(Callees),
     {200, Json};
 
-handle_req(<<"mon_start">>, Params) ->
+do_handle_req(<<"mon_start">>, Params) ->
     Query = get_query(Params),
 
     lager:info("Starting monitoring via web on '~s'~n", [Query]),
@@ -269,7 +275,7 @@ handle_req(<<"mon_start">>, Params) ->
             {400, Json}
     end;
 
-handle_req(<<"mon_stop">>, Params) ->
+do_handle_req(<<"mon_stop">>, Params) ->
     MFA = {M, F, A} = get_mfa(Params),
 
     lager:info("Stopping monitoring via web on ~w:~w/~w~n",[M, F, A]),
@@ -277,7 +283,7 @@ handle_req(<<"mon_stop">>, Params) ->
     xprof_core:demonitor(MFA),
     204;
 
-handle_req(<<"mon_get_all">>, _Params) ->
+do_handle_req(<<"mon_get_all">>, _Params) ->
     Funs = xprof_core:get_all_monitored(),
     FunsArr = [{[{<<"mfa">>, [Mod, Fun, Arity]},
                  {<<"query">>, Query},
@@ -287,7 +293,7 @@ handle_req(<<"mon_get_all">>, _Params) ->
     Json = jsone:encode(FunsArr),
     {200, Json};
 
-handle_req(<<"data">>, Params) ->
+do_handle_req(<<"data">>, Params) ->
     MFA = get_mfa(Params),
     LastTS = get_int(<<"last_ts">>, Params, 0),
 
@@ -299,7 +305,7 @@ handle_req(<<"data">>, Params) ->
             {200, Json}
     end;
 
-handle_req(<<"trace_set">>, Params) ->
+do_handle_req(<<"trace_set">>, Params) ->
     case proplists:get_value(<<"spec">>, Params) of
         <<"all">> ->
             xprof_core:trace(all),
@@ -312,12 +318,12 @@ handle_req(<<"trace_set">>, Params) ->
             400
     end;
 
-handle_req(<<"trace_status">>, _Params) ->
+do_handle_req(<<"trace_status">>, _Params) ->
     {_, Status} = xprof_core:get_trace_status(),
     Json = jsone:encode({[{status, Status}]}),
     {200, Json};
 
-handle_req(<<"capture">>, Params) ->
+do_handle_req(<<"capture">>, Params) ->
     MFA = {M, F, A} = get_mfa(Params),
     Threshold = get_int(<<"threshold">>, Params),
     Limit = get_int(<<"limit">>, Params),
@@ -334,7 +340,7 @@ handle_req(<<"capture">>, Params) ->
             404
     end;
 
-handle_req(<<"capture_stop">>, Params) ->
+do_handle_req(<<"capture_stop">>, Params) ->
     MFA = get_mfa(Params),
 
     lager:info("Stopping slow calls capturing for ~p", [MFA]),
@@ -348,7 +354,7 @@ handle_req(<<"capture_stop">>, Params) ->
             404
     end;
 
-handle_req(<<"capture_data">>, Params) ->
+do_handle_req(<<"capture_data">>, Params) ->
     MFA  = get_mfa(Params),
     Offset = get_int(<<"offset">>, Params, 0),
 
@@ -364,7 +370,7 @@ handle_req(<<"capture_data">>, Params) ->
             {200, Json}
     end;
 
-handle_req(<<"mode">>, _Params) ->
+do_handle_req(<<"mode">>, _Params) ->
     Mode = xprof_core:get_mode(),
     Json = jsone:encode({[{mode, Mode}]}),
     {200, Json}.

--- a/apps/xprof_gui/test/xprof_http_e2e_SUITE.erl
+++ b/apps/xprof_gui/test/xprof_http_e2e_SUITE.erl
@@ -41,7 +41,8 @@
          but_it_should_return_elixir_if_it_is_forced_as_setting/1,
          explore_callees_of_standard_function/1,
          explore_callees_on_not_existing_function/1,
-         explore_callees_in_elixir_mode/1
+         explore_callees_in_elixir_mode/1,
+         core_not_running/1
         ]).
 
 %% CT funs
@@ -80,7 +81,8 @@ groups() ->
        in_this_project_we_should_detect_erlang,
        but_it_should_return_elixir_if_it_is_forced_as_setting,
        explore_callees_of_standard_function,
-       explore_callees_on_not_existing_function
+       explore_callees_on_not_existing_function,
+       core_not_running
       ]},
      {elixir,
       [],
@@ -365,6 +367,12 @@ explore_callees_in_elixir_mode(_Config) ->
             io:format("Elixir not found, skipping test."),
             ok
     end.
+
+core_not_running(_Config) ->
+    ok = application:stop(xprof_core),
+    ?assertEqual({500, []}, make_get_request("api/trace_status")),
+    ?assertEqual({500, []}, make_get_request("api/all_monitored")),
+    ok.
 
 %%
 %% Givens


### PR DESCRIPTION
For example xprof_core might not be started (or crashed) and some
gen_server calls might fail with noproc.