### PR TITLE
Support typed records - second try

### DIFF
--- a/apps/xprof_core/src/xprof_core_ms.erl
+++ b/apps/xprof_core/src/xprof_core_ms.erl
@@ -65,7 +65,7 @@ ms_transform(Clauses, RecDefs) ->
     Result = compile:forms(
                wrap_forms(wrap_args(Clauses), RecDefs),
                [{parse_transform, ms_transform},
-                export_all, binary, dpp, return_errors]),
+                export_all, binary, 'P', return_errors]),
     case Result of
         {ok, [], Forms} ->
             unwrap_forms(Forms);

--- a/apps/xprof_core/src/xprof_core_records.erl
+++ b/apps/xprof_core/src/xprof_core_records.erl
@@ -113,7 +113,8 @@ get_record_defs(Mod) ->
             case beam_lib:chunks(Bin, [abstract_code]) of
                 {ok, {_Mod, [{abstract_code, {raw_abstract_v1, Forms}}]}} ->
                     Defs =
-                        [{RecName, RecDef} || {attribute, _Anno, record, {RecName, _Fields}} = RecDef <- Forms],
+                        [{RecName, {attribute, Anno, record, {RecName, remove_types(Fields)}}}
+                         || {attribute, Anno, record, {RecName, Fields}} <- Forms],
                     Defs;
                 _Error ->
                     []
@@ -121,6 +122,13 @@ get_record_defs(Mod) ->
         error ->
             []
     end.
+
+remove_types([{typed_record_field, Field, _Type} | Fs]) ->
+    [Field | remove_types(Fs)];
+remove_types([Field | Fs]) ->
+    [Field | remove_types(Fs)];
+remove_types([]) ->
+    [].
 
 %% Taken from `shell:record_print_fun/1'
 record_print_fun(RecName, NumFields) ->
@@ -136,7 +144,5 @@ record_fields([{record_field,_,{atom,_,Field}} | Fs]) ->
     [Field | record_fields(Fs)];
 record_fields([{record_field,_,{atom,_,Field},_} | Fs]) ->
     [Field | record_fields(Fs)];
-record_fields([{typed_record_field,Field,_Type} | Fs]) ->
-    record_fields([Field | Fs]);
 record_fields([]) ->
     [].

--- a/apps/xprof_core/test/xprof_core_ms_tests.erl
+++ b/apps/xprof_core/test/xprof_core_ms_tests.erl
@@ -84,6 +84,10 @@ ms_test_() ->
          "at column 7"},
         ?M:fun2ms("m:f(A = {B, _}) -> {A, B}")),
      ?_assertEqual(
+        {error,
+         "variable 'B' is unbound at column 17"},
+        ?M:fun2ms("m:f(A) when A > B")),
+     ?_assertEqual(
         {ok, {{m, f, 0},
               {[{[],[],[{exception_trace},{message,arity},true]}],
                [{[],[],[{exception_trace},{message,'$_'},true]}]}}},


### PR DESCRIPTION
We use `compile:forms` to convert a fun to a match-spec using the
`ms_transorm` parse-transform. To also recognise records the
record definitions are fetched from the source module and
included in the compiled forms. However the definitions might
contain typed fields referencing local user type definitions
(which are not included) and the linter would emmit
an error on these unknown local types.

Previous attempt to address this (in commit adca1349) changed the
`P` compiler option to `dpp` which does not run the linter.
However we still want to catch and pretty print other errors
(like unbound variable usage).

So this next attempt instead removes the type annotation from
record defs when they are stored in ETS, and restores calling the
compiler with the `P` option.

Without this change an unbound variable caused the below crash when converting the AST of the converted match-spec back to a literal term (which cannot contain variables)
```
{error,
                        {badarg,{var,{1,17},'B'}},
                        [{erl_syntax,concrete,1,
                             [{file,"erl_syntax.erl"},{line,7305}]}
...
```
closes #26