### PR TITLE
Allow configuring web interface listen address 

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ You can configure `xprof` by changing its application variables:
 
 Key                    | Default        | Description
 :----------------------|:---------------|:-----------
+`ip`                   | any            | Listen address of the web interface (in tuple format, see [`inet:ip_address()`](http://erlang.org/doc/man/inet.html#type-ip_address))
 `port`                 | 7890           | Port for the web interface
 `max_tracer_queue_len` | 1000           | Overflow protection. If main tracer proccess will have more than 1000 messages in its process queue tracing will be stopped and one needs to use trace button to resume. The purpose of this is to prevent out of memory crashes when tracer process is not able to process incomming traces fast enough. This may happen when we trace very "hot" function.
 `max_duration`         | 30000          | The largest duration value in ms. In case a call takes even longer, this maximum value is stored instead.

--- a/README.md
+++ b/README.md
@@ -101,17 +101,17 @@ false.
 
 ## Configuration
 
-You can configure `xprof` by changing its application variables:
+You can configure XProf by changing the below application variables:
 
-Key                    | Default        | Description
-:----------------------|:---------------|:-----------
-`ip`                   | any            | Listen address of the web interface (in tuple format, see [`inet:ip_address()`](http://erlang.org/doc/man/inet.html#type-ip_address))
-`port`                 | 7890           | Port for the web interface
-`max_tracer_queue_len` | 1000           | Overflow protection. If main tracer proccess will have more than 1000 messages in its process queue tracing will be stopped and one needs to use trace button to resume. The purpose of this is to prevent out of memory crashes when tracer process is not able to process incomming traces fast enough. This may happen when we trace very "hot" function.
-`max_duration`         | 30000          | The largest duration value in ms. In case a call takes even longer, this maximum value is stored instead.
-`ignore_recursion`     | true           | Whether to only measure the outermost call to a recursive function or not (ie. measure all calls).
-`mode`                 | <autodetected> | Syntax mode (`erlang` or `elixir`)
-`load_records`         | []             | List of modules from which to load record definitions at startup.
+Application  | Key                    | Default        | Description
+:------------|:-----------------------|:---------------|:-----------
+`xprof_gui`  | `ip`                   | any            | Listen address of the web interface (in tuple format, see [`inet:ip_address()`](http://erlang.org/doc/man/inet.html#type-ip_address))
+`xprof_gui`  | `port`                 | 7890           | Port for the web interface
+`xprof_core` | `max_tracer_queue_len` | 1000           | Overflow protection. If main tracer proccess will have more than 1000 messages in its process queue tracing will be stopped and one needs to use trace button to resume. The purpose of this is to prevent out of memory crashes when tracer process is not able to process incomming traces fast enough. This may happen when we trace very "hot" function.
+`xprof_core` | `max_duration`         | 30000          | The largest duration value in ms. In case a call takes even longer, this maximum value is stored instead.
+`xprof_core` | `ignore_recursion`     | true           | Whether to only measure the outermost call to a recursive function or not (ie. measure all calls).
+`xprof_core` | `mode`                 | <autodetected> | Syntax mode (`erlang` or `elixir`)
+`xprof_core` | `load_records`         | []             | List of modules from which to load record definitions at startup.
 
 ## XProf flavoured match-spec funs
 

--- a/apps/xprof_core/src/xprof_core_lib.erl
+++ b/apps/xprof_core/src/xprof_core_lib.erl
@@ -32,11 +32,11 @@ now2epoch({MS, S, _US}) ->
 
 -spec set_mode(xprof_core:mode()) -> ok.
 set_mode(Mode) when Mode =:= elixir; Mode =:= erlang ->
-    application:set_env(xprof, mode, Mode).
+    application:set_env(xprof_core, mode, Mode).
 
 -spec get_mode() -> xprof_core:mode().
 get_mode() ->
-    case application:get_env(xprof, mode) of
+    case application:get_env(xprof_core, mode) of
         undefined ->
             Mode = detect_mode(),
             set_mode(Mode),

--- a/apps/xprof_core/src/xprof_core_records.erl
+++ b/apps/xprof_core/src/xprof_core_records.erl
@@ -71,7 +71,7 @@ record_print_fun() ->
 
 init([]) ->
     ets:new(?TABLE, [set, protected, named_table, {read_concurrency, true}]),
-    Mods = application:get_env(xprof, load_records, []),
+    Mods = application:get_env(xprof_core, load_records, []),
     RecNames = lists:flatmap(fun get_and_store_record_defs/1, Mods),
     lager:info("Loaded records: ~p", [RecNames]),
     {ok, #state{}}.

--- a/apps/xprof_core/src/xprof_core_trace_handler.erl
+++ b/apps/xprof_core/src/xprof_core_trace_handler.erl
@@ -116,8 +116,8 @@ get_captured_data(MFA, Offset) when Offset >= 0 ->
 %% gen_server callbacks
 
 init([MFASpec, Name]) ->
-    MaxDuration = application:get_env(xprof, max_duration, ?MAX_DURATION) * 1000,
-    IgnoreRecursion = application:get_env(xprof, ignore_recursion, true),
+    MaxDuration = application:get_env(xprof_core, max_duration, ?MAX_DURATION) * 1000,
+    IgnoreRecursion = application:get_env(xprof_core, ignore_recursion, true),
     {ok, HDR} = init_storage(Name, MaxDuration),
     %% add trace pattern with args capturing turned off
     capture_args_trace_off(MFASpec),

--- a/apps/xprof_core/src/xprof_core_tracer.erl
+++ b/apps/xprof_core/src/xprof_core_tracer.erl
@@ -79,7 +79,7 @@ trace_status() ->
 
 init([]) ->
     init_tracer(),
-    MaxQueueLen = application:get_env(xprof, max_tracer_queue_len, 1000),
+    MaxQueueLen = application:get_env(xprof_core, max_tracer_queue_len, 1000),
     {ok, #state{max_queue_len = MaxQueueLen}}.
 
 handle_call({monitor, MFASpec, Query}, _From, State) ->

--- a/apps/xprof_core/test/xprof_core_erlang_syntax_tests.erl
+++ b/apps/xprof_core/test/xprof_core_erlang_syntax_tests.erl
@@ -12,12 +12,12 @@
 fmt_test_() ->
     {setup,
      fun() ->
-             ok = application:set_env(xprof, load_records, [?MODULE]),
+             ok = application:set_env(xprof_core, load_records, [?MODULE]),
              {ok, Pid} = xprof_core_records:start_link(),
              Pid
      end,
      fun(Pid) ->
-             application:unset_env(xprof, load_records),
+             application:unset_env(xprof_core, load_records),
              unlink(Pid),
              exit(Pid, kill)
      end,

--- a/apps/xprof_core/test/xprof_core_ms_tests.erl
+++ b/apps/xprof_core/test/xprof_core_ms_tests.erl
@@ -99,12 +99,12 @@ records_test_() ->
               [{[{rec,1,'_'}], [], [{exception_trace},{message,'$_'},true]}]},
     {setup,
      fun() ->
-             ok = application:set_env(xprof, load_records, [?MODULE]),
+             ok = application:set_env(xprof_core, load_records, [?MODULE]),
              {ok, Pid} = xprof_core_records:start_link(),
              Pid
      end,
      fun(Pid) ->
-             application:unset_env(xprof, load_records),
+             application:unset_env(xprof_core, load_records),
              unlink(Pid),
              exit(Pid, kill)
      end,
@@ -158,7 +158,7 @@ fun2ms_elixir_test_() ->
     Tests =
         {setup,
          fun() -> xprof_core_lib:set_mode(elixir) end,
-         fun(_) -> application:unset_env(xprof, mode) end,
+         fun(_) -> application:unset_env(xprof_core, mode) end,
          [?_assertEqual(elixir, xprof_core_lib:get_mode()),
           ?_assertEqual({ok, {{'Elixir.Mod','fun',1}, ?DEFAULT_MS}},
                         ?M:fun2ms("Mod.fun/1")),

--- a/apps/xprof_core/test/xprof_core_test_lib.erl
+++ b/apps/xprof_core/test/xprof_core_test_lib.erl
@@ -70,7 +70,7 @@ setup_elixir(ElixirEbin) ->
                 true = code:add_patha(ElixirEbin),
                 ElixirEbin
         end,
-    application:unset_env(xprof, mode),
+    application:unset_env(xprof_core, mode),
     {ok, Apps} = application:ensure_all_started(elixir),
     {ElixirEbin1, Apps}.
 
@@ -87,7 +87,7 @@ get_elixir_ebin(Elixir) ->
     end.
 
 cleanup_elixir({ElixirEbin, Apps}) ->
-    application:unset_env(xprof, mode),
+    application:unset_env(xprof_core, mode),
     [ok = application:stop(App) || App <- Apps],
     del_elixir_from_path(ElixirEbin),
     ok.

--- a/apps/xprof_core/test/xprof_tracing_SUITE.erl
+++ b/apps/xprof_core/test/xprof_tracing_SUITE.erl
@@ -236,7 +236,7 @@ monitor_recursive_fun(_Config) ->
     ok.
 
 monitor_keep_recursive_fun(_Config) ->
-    application:set_env(xprof, ignore_recursion, false),
+    application:set_env(xprof_core, ignore_recursion, false),
     xprof_core:monitor(MFA = {?MODULE, recursive_test_fun, 1}),
     ok = xprof_core:trace(self()),
 
@@ -254,7 +254,7 @@ monitor_keep_recursive_fun(_Config) ->
 
     xprof_core:trace(pause),
     xprof_core:demonitor(MFA),
-    application:unset_env(xprof, ignore_recursion),
+    application:unset_env(xprof_core, ignore_recursion),
     ok.
 
 monitor_ms(_Config) ->
@@ -410,7 +410,7 @@ capture_stop(_Config) ->
     ok.
 
 long_call(_Config) ->
-    application:set_env(xprof, max_duration, 100),
+    application:set_env(xprof_core, max_duration, 100),
 
     xprof_core:monitor(MFA = {?MODULE, test_fun, 1}),
     ok = xprof_core:trace(self()),
@@ -436,7 +436,7 @@ long_call(_Config) ->
     xprof_core:trace(pause),
     xprof_core:demonitor(MFA),
 
-    application:unset_env(xprof, max_duration),
+    application:unset_env(xprof_core, max_duration),
 
     %% check times as a last thing because they fail sometimes with a big
     %% precision error

--- a/apps/xprof_gui/src/xprof_gui_app.erl
+++ b/apps/xprof_gui/src/xprof_gui_app.erl
@@ -9,6 +9,7 @@
          stop/1]).
 
 -define(APP, xprof_gui).
+-define(DEF_WEB_IF_IP, any).
 -define(DEF_WEB_IF_PORT, 7890).
 -define(LISTENER, xprof_http_listener).
 -ifdef(COWBOY_VERSION_1).
@@ -34,9 +35,10 @@ stop(_State) ->
 %% Internal functions
 
 start_cowboy() ->
+    IP = application:get_env(?APP, ip, ?DEF_WEB_IF_IP),
     Port = application:get_env(?APP, port, ?DEF_WEB_IF_PORT),
     Dispatch = cowboy_dispatch(?HANDLER_MOD),
-    ?HANDLER_MOD:start_listener(?LISTENER, Port, Dispatch).
+    ?HANDLER_MOD:start_listener(?LISTENER, IP, Port, Dispatch).
 
 cowboy_dispatch(Mod) ->
     StaticDir = get_static_dir(),

--- a/apps/xprof_gui/src/xprof_gui_cowboy1_handler.erl
+++ b/apps/xprof_gui/src/xprof_gui_cowboy1_handler.erl
@@ -6,7 +6,7 @@
 -behavior(cowboy_http_handler).
 
 %% xprof_gui_app callback
--export([start_listener/3]).
+-export([start_listener/4]).
 
 %% Cowboy 1.x callbacks
 -export([init/3,
@@ -26,8 +26,8 @@
 
 %% xprof_gui_app callback
 
-start_listener(Name, Port, Dispatch) ->
-    cowboy:start_http(Name, 100, [{port, Port}],
+start_listener(Name, IP, Port, Dispatch) ->
+    cowboy:start_http(Name, 100, [{ip, IP}, {port, Port}],
                       [{env, [{dispatch, Dispatch}]}]).
 
 %% Cowboy 1.x callbacks

--- a/apps/xprof_gui/src/xprof_gui_cowboy2_handler.erl
+++ b/apps/xprof_gui/src/xprof_gui_cowboy2_handler.erl
@@ -6,7 +6,7 @@
 -behavior(cowboy_handler).
 
 %% xprof_gui_app callback
--export([start_listener/3]).
+-export([start_listener/4]).
 
 %% Cowboy 2.x callback
 -export([init/2]).
@@ -21,8 +21,8 @@
 
 %% xprof_gui_app callback
 
-start_listener(Name, Port, Dispatch) ->
-    cowboy:start_clear(Name, [{port, Port}],
+start_listener(Name, IP, Port, Dispatch) ->
+    cowboy:start_clear(Name, [{ip, IP}, {port, Port}],
                        #{env => #{dispatch => Dispatch}}).
 
 %% Cowboy 2.x callback

--- a/apps/xprof_gui/test/xprof_http_e2e_SUITE.erl
+++ b/apps/xprof_gui/test/xprof_http_e2e_SUITE.erl
@@ -384,10 +384,10 @@ given_tracing_all() ->
     ok.
 
 given_overload_queue_limit(Limit) ->
-    application:set_env(xprof, max_tracer_queue_len, Limit).
+    application:set_env(xprof_core, max_tracer_queue_len, Limit).
 
 given_elixir_mode_is_set() ->
-    application:set_env(xprof, mode, elixir).
+    application:set_env(xprof_core, mode, elixir).
 
 given_traced(Fun) ->
     {204, _} = make_get_request("api/mon_start", [{"query", Fun}]),
@@ -406,7 +406,7 @@ given_capture_slow_calls_of(Mod, Fun, Arity, Threshold, Limit) ->
 %% Helpers
 %%
 restore_default_mode() ->
-    application:set_env(xprof, mode, erlang).
+    application:set_env(xprof_core, mode, erlang).
 
 long_function() ->
     timer:sleep(50),

--- a/apps/xprof_gui/test/xprof_http_e2e_SUITE.erl
+++ b/apps/xprof_gui/test/xprof_http_e2e_SUITE.erl
@@ -122,6 +122,8 @@ init_per_testcase(TestCase, Config) ->
         _ ->
             given_overload_queue_limit(1000)
     end,
+    %% test configuring non-default address
+    application:set_env(xprof_gui, ip, {127, 0, 0, 1}),
     %% use a different port for tests than the default one
     application:set_env(xprof_gui, port, ?TEST_PORT),
     {ok, StartedApps} = xprof:start(),


### PR DESCRIPTION
Fixes #159

While at it also move all application env vars from `xprof` to `xprof_core` app 