### PR TITLE
Address hdr_histogram issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,13 @@ branches:
     only:
         - master
         - release_2.0
+        - hist
 matrix:
     include:
         - otp_release: 20.0
         - otp_release: 19.3
+        - otp_release: 19.3
+          env: XPROF_ERL_HIST=true
         - otp_release: 18.3
           env: COWBOY_VERSION=1.1.2
         - otp_release: 17.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ branches:
     only:
         - master
         - release_2.0
-        - hist
 matrix:
     include:
         - otp_release: 20.0

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ Registry.dispatch(MyApp.Registry, "topic1", _) -> nil; (MyApp.Registry, "topic2"
 
 ## Erlang records
 
-Elrang record syntax is supported in the queries and works similar to the Erlang
+Erlang record syntax is supported in the queries and works similar to the Erlang
 shell. XProf keeps a single global list of loaded record definitions. Record
 definitions can be loaded at startup time from modules listed in app env
 `load_records` or at runtime calling `xprof_core:rr(Module)` (see documentation
@@ -207,6 +207,19 @@ of `xprof_core` for more details). The record definitions are extracted from
 debug_info of the beam files belonging to the loaded modules. As the list is
 global there can be only one record with the same name loaded at a time and
 records loaded later might override previously loaded ones.
+
+## Compile-time configuration
+
+`XPROF_ERL_HIST` - By default XProf uses the `hdr_histogram_erl` NIF
+library. If you have compilation problems you can choose to use a
+native Erlang histogram implementation by defining the OS env var
+`XPROF_ERL_HIST` when compiling `xprof_core`.
+
+`COWBOY_VERSION` - By default XProf uses Cowboy version 2.x. This
+version is only supported from Erlang/OTP 19 and is not backwards
+compatible with older Cowboy versions. If for some reason you would
+like to use Cowboy version 1.x you can define the OS env var
+`COWBOY_VERSION=1` when compiling `xprof_gui`.
 
 ## Contributing
 

--- a/apps/xprof_core/rebar.config
+++ b/apps/xprof_core/rebar.config
@@ -5,4 +5,6 @@
 
 {erl_opts, [debug_info,
             {parse_transform, lager_transform},
-            {platform_define, "^((1[8|9])|2)", rand_module}]}.
+            {platform_define, "^((1[8|9])|2)", rand_module},
+            {platform_define, "^[^R1]", ceil_floor}
+           ]}.

--- a/apps/xprof_core/rebar.config
+++ b/apps/xprof_core/rebar.config
@@ -1,5 +1,5 @@
 {deps,
- [{customized_hdr_histogram, "0.3.2"},
+ [{hdr_histogram, "0.3.2"},
   {lager, "3.2.4"}
  ]}.
 

--- a/apps/xprof_core/rebar.config
+++ b/apps/xprof_core/rebar.config
@@ -5,6 +5,7 @@
 
 {erl_opts, [debug_info,
             {parse_transform, lager_transform},
+            {platform_define, "^(R|17|18)", before_OTP_19},
             {platform_define, "^((1[8|9])|2)", rand_module},
             {platform_define, "^[^R1]", ceil_floor}
            ]}.

--- a/apps/xprof_core/rebar.config.script
+++ b/apps/xprof_core/rebar.config.script
@@ -1,0 +1,12 @@
+case os:getenv("XPROF_ERL_HIST") of
+    false ->
+        CONFIG;
+    _ ->
+        ErlOpts = proplists:get_value(erl_opts, CONFIG, []),
+        NewErlOpts = {erl_opts, [{d, 'XPROF_ERL_HIST'}|ErlOpts]},
+        Config2 = lists:keystore(erl_opts, 1, CONFIG, NewErlOpts),
+
+        Deps = proplists:get_value(deps, CONFIG, []),
+        NewDeps = {deps, lists:keydelete(hdr_histogram, 1, Deps)},
+        lists:keystore(deps, 1, Config2, NewDeps)
+end.

--- a/apps/xprof_core/src/xprof_core.app.src
+++ b/apps/xprof_core/src/xprof_core.app.src
@@ -8,7 +8,7 @@
    ,stdlib
    ,compiler
    ,lager
-   ,customized_hdr_histogram
+   ,hdr_histogram
    ]}
  ,{env,[]}
  ,{modules, []}

--- a/apps/xprof_core/src/xprof_core_cmd_funlatency.erl
+++ b/apps/xprof_core/src/xprof_core_cmd_funlatency.erl
@@ -86,7 +86,7 @@ init(Options, _MFASpec) ->
                   undefined -> undefined;
                   _ -> 0
               end,
-    {ok, HDR} = xprof_core_hist:new(MaxDuration, 3),
+    {ok, HDR} = xprof_core_hist:hdr_new(MaxDuration, 3),
     {ok, #state{hdr_ref = HDR,
                 max_duration = MaxDuration,
                 ignore_recursion = IgnoreRecursion,
@@ -116,9 +116,9 @@ handle_event({trace_ts, Pid, Tag, MFA, RetOrExc, EndTime},
                             lager:error("Call ~p took ~p ms that is larger than the maximum "
                                         "that can be stored (~p ms)",
                                         [MFA, CallTime/1000, MaxDuration div 1000]),
-                            ok = xprof_core_hist:record(Ref, MaxDuration);
+                            ok = xprof_core_hist:hdr_record(Ref, MaxDuration);
                        true ->
-                            ok = xprof_core_hist:record(Ref, CallTime)
+                            ok = xprof_core_hist:hdr_record(Ref, CallTime)
                     end,
 
                     maybe_capture({Pid, CallTime, Args, {Tag, NewRet}},
@@ -128,7 +128,7 @@ handle_event({trace_ts, Pid, Tag, MFA, RetOrExc, EndTime},
 
 take_snapshot(State = #state{hdr_ref = Ref, nomatch_count = NoMatch}) ->
     Snapshot = get_current_hist_stats(Ref, NoMatch),
-    xprof_core_hist:reset(Ref),
+    xprof_core_hist:hdr_reset(Ref),
     maybe_reset_nomatch_count(Snapshot, State, NoMatch).
 
 maybe_reset_nomatch_count(Snapshot, _State, _NoMatch = undefined) ->
@@ -211,7 +211,7 @@ maybe_capture({_Pid, CallTime, Args, _Res} = Item, Threshold, _State) ->
     end.
 
 get_current_hist_stats(HistRef, NoMatch) ->
-    [{count, Count}|_] = Stats = xprof_core_hist:stats(HistRef),
+    [{count, Count}|_] = Stats = xprof_core_hist:hdr_stats(HistRef),
     case NoMatch of
         undefined ->
             Stats;

--- a/apps/xprof_core/src/xprof_core_cmd_funlatency.erl
+++ b/apps/xprof_core/src/xprof_core_cmd_funlatency.erl
@@ -86,7 +86,7 @@ init(Options, _MFASpec) ->
                   undefined -> undefined;
                   _ -> 0
               end,
-    {ok, HDR} = hdr_histogram:open(MaxDuration, 3),
+    {ok, HDR} = xprof_core_hist:new(MaxDuration, 3),
     {ok, #state{hdr_ref = HDR,
                 max_duration = MaxDuration,
                 ignore_recursion = IgnoreRecursion,
@@ -116,9 +116,9 @@ handle_event({trace_ts, Pid, Tag, MFA, RetOrExc, EndTime},
                             lager:error("Call ~p took ~p ms that is larger than the maximum "
                                         "that can be stored (~p ms)",
                                         [MFA, CallTime/1000, MaxDuration div 1000]),
-                            ok = hdr_histogram:record(Ref, MaxDuration);
+                            ok = xprof_core_hist:record(Ref, MaxDuration);
                        true ->
-                            ok = hdr_histogram:record(Ref, CallTime)
+                            ok = xprof_core_hist:record(Ref, CallTime)
                     end,
 
                     maybe_capture({Pid, CallTime, Args, {Tag, NewRet}},
@@ -128,7 +128,7 @@ handle_event({trace_ts, Pid, Tag, MFA, RetOrExc, EndTime},
 
 take_snapshot(State = #state{hdr_ref = Ref, nomatch_count = NoMatch}) ->
     Snapshot = get_current_hist_stats(Ref, NoMatch),
-    hdr_histogram:reset(Ref),
+    xprof_core_hist:reset(Ref),
     maybe_reset_nomatch_count(Snapshot, State, NoMatch).
 
 maybe_reset_nomatch_count(Snapshot, _State, _NoMatch = undefined) ->
@@ -211,30 +211,16 @@ maybe_capture({_Pid, CallTime, Args, _Res} = Item, Threshold, _State) ->
     end.
 
 get_current_hist_stats(HistRef, NoMatch) ->
-    Count = hdr_histogram:get_total_count(HistRef),
-    TotalCountAndRate =
-        case NoMatch of
-            undefined ->
-                [];
-            _ ->
-                TotalCount = Count + NoMatch,
-                [{total_count, TotalCount},
-                 {match_rate, percent(Count, TotalCount)}]
-        end,
-    [{min,         hdr_histogram:min(HistRef)},
-     {mean,        hdr_histogram:mean(HistRef)},
-     %%{median,      hdr_histogram:median(HistRef)},
-     {max,         hdr_histogram:max(HistRef)},
-     %%{stddev,      hdr_histogram:stddev(HistRef)},
-     %%{p25,         hdr_histogram:percentile(HistRef,25.0)},
-     {p50,         hdr_histogram:percentile(HistRef,50.0)},
-     {p75,         hdr_histogram:percentile(HistRef,75.0)},
-     {p90,         hdr_histogram:percentile(HistRef,90.0)},
-     {p99,         hdr_histogram:percentile(HistRef,99.0)},
-     %%{p9999999,    hdr_histogram:percentile(HistRef,99.9999)},
-     %%{memsize,     hdr_histogram:get_memory_size(HistRef)},
-     {count,       Count}
-     |TotalCountAndRate].
+    [{count, Count}|_] = Stats = xprof_core_hist:stats(HistRef),
+    case NoMatch of
+        undefined ->
+            Stats;
+        _ ->
+            TotalCount = Count + NoMatch,
+            [{total_count, TotalCount},
+             {match_rate, percent(Count, TotalCount)}
+             |Stats]
+    end.
 
 percent(_, 0) ->
     0;

--- a/apps/xprof_core/src/xprof_core_hist.erl
+++ b/apps/xprof_core/src/xprof_core_hist.erl
@@ -167,7 +167,7 @@ do_new(Table, Min, Max, Precision)
        andalso 1 =< Precision andalso Precision =< 5 ->
 
     LargestValueWithSingleUnitResolution = 2 * math:pow(10, Precision),
-    SubBucketCountMagnitude = int_ceil(math:log2(LargestValueWithSingleUnitResolution)),
+    SubBucketCountMagnitude = int_ceil(math_log2(LargestValueWithSingleUnitResolution)),
 
     SubBucketHalfCountMagnitude =
         case SubBucketCountMagnitude < 1 of
@@ -176,7 +176,7 @@ do_new(Table, Min, Max, Precision)
         end,
 
     UnitMagnitude =
-        case int_floor(math:log2(Min)) of
+        case int_floor(math_log2(Min)) of
             N when N < 0 -> 0;
             N -> N
         end,
@@ -531,5 +531,21 @@ int_floor(F) ->
     if R > F -> R - 1;
        true -> R
     end.
+
+-endif.
+
+%% FIXME OTP 19+
+%% Remove this section when we no longer support old Erlang versions
+%% (R16B - 18)
+-ifdef(before_OTP_19).
+
+math_log2(V) ->
+    math:log(V)/math:log(2).
+
+-else.
+
+%% math:log2 was introduced in OTP 18
+math_log2(V) ->
+    math:log2(V).
 
 -endif.

--- a/apps/xprof_core/src/xprof_core_hist.erl
+++ b/apps/xprof_core/src/xprof_core_hist.erl
@@ -1,0 +1,484 @@
+%%%
+%%% High Dynamic Range (HDR) Histogram for Erlang
+%%%
+%%% This implementation is based on the Elixir version found at
+%%% https://github.com/2nd/histogrex/ with adjustments based on
+%%% https://github.com/HdrHistogram/hdr_histogram_erl.
+%%%
+
+%%%
+%%% The MIT License (MIT)
+%%% 
+%%% Copyright (c) 2017 Second Spectrum
+%%% 
+%%% Permission is hereby granted, free of charge, to any person obtaining a copy
+%%% of this software and associated documentation files (the "Software"), to deal
+%%% in the Software without restriction, including without limitation the rights
+%%% to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+%%% copies of the Software, and to permit persons to whom the Software is
+%%% furnished to do so, subject to the following conditions:
+%%% 
+%%% The above copyright notice and this permission notice shall be included in all
+%%% copies or substantial portions of the Software.
+%%% 
+%%% THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+%%% IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+%%% FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+%%% AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+%%% LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+%%% OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+%%% SOFTWARE.
+
+-module(xprof_core_hist).
+
+-export([new/2,
+         new/3,
+         new_concurrent/4,
+         record/2,
+         record_many/3,
+         reset/1,
+         delete/1,
+
+         total_count/1,
+         max/1,
+         min/1,
+         mean/1,
+         percentile/2,
+
+         stats/1
+        ]).
+
+%% compatibility API with hdr_histogram_erl for testing
+-export([open/2,
+         open/3,
+         close/1,
+         get_total_count/1,
+         same/3
+        ]).
+
+-define(TABLE, ?MODULE).
+
+-define(TOTAL_COUNT_INDEX, 2).
+
+-record(hist,
+        {table,
+         %% field names from elixir
+         name,
+         bucket_count,
+         counts_length,
+         unit_magnitude,
+         sub_bucket_mask,
+         sub_bucket_count,
+         sub_bucket_half_count,
+         sub_bucket_half_count_magnitude
+
+         %% additional field names from C
+         , min %% lowest_trackable_value,
+         , max %% highest_trackable_value,
+         , precision %% significant_figures
+        }).
+
+%%
+%% Aliases from hdr_histogram NIF API
+%%
+
+open(Max, Prec) ->
+    new(1, Max, Prec).
+
+open(Name, Max, Prec) ->
+    new_concurrent(Name, 1, Max, Prec).
+
+close(H) ->
+    delete(H).
+
+get_total_count(H) ->
+    total_count(H).
+
+same(H, A, B) ->
+    ets:first(H#hist.table), %% badarg if H was deleted (table does not exist)
+    lowest_equivalent_value(H, A) =:= lowest_equivalent_value(H, B).
+
+%%-----------
+
+new(Max, Precision) ->
+    new(1, Max, Precision).
+
+new(Min, Max, Precision) ->
+    Tid = storage_new(),
+    do_new(Tid, Min, Max, Precision).
+
+new_concurrent(Name, Min, Max, Precision) ->
+    Tid = storage_new_concurrent(Name),
+    do_new(Tid, Min, Max, Precision).
+
+do_new(Table, Min, Max, Precision)
+  when Min > 0 andalso Max > Min
+       andalso 1 =< Precision andalso Precision =< 5 ->
+
+    LargestValueWithSingleUnitResolution = 2 * math:pow(10, Precision),
+    SubBucketCountMagnitude = int_ceil(math:log2(LargestValueWithSingleUnitResolution)),
+
+    SubBucketHalfCountMagnitude =
+        case SubBucketCountMagnitude < 1 of
+            true -> 1;
+            false -> SubBucketCountMagnitude - 1
+        end,
+
+    UnitMagnitude =
+        case int_floor(math:log2(Min)) of
+            N when N < 0 -> 0;
+            N -> N
+        end,
+
+    SubBucketCount = round(math:pow(2, SubBucketHalfCountMagnitude + 1)),
+    SubBucketHalfCount = round(SubBucketCount / 2),
+    SubBucketMask = (SubBucketCount - 1) bsl UnitMagnitude,
+
+    BucketCount = calculate_bucket_count(SubBucketCount bsl UnitMagnitude, Max, 1),
+    CountsLength = round((BucketCount + 1) * (SubBucketCount / 2)),
+
+    H = #hist{
+           table = Table,
+           name = hist_key,
+           bucket_count = BucketCount,
+           counts_length = CountsLength,
+           unit_magnitude = UnitMagnitude,
+           sub_bucket_mask = SubBucketMask,
+           sub_bucket_count = SubBucketCount,
+           sub_bucket_half_count = SubBucketHalfCount,
+           sub_bucket_half_count_magnitude = SubBucketHalfCountMagnitude,
+
+           min = Min,
+           max = Max,
+           precision = Precision
+          },
+    reset(H),
+    {ok, H}.
+
+record(H, Value) when is_integer(Value) ->
+    do_record(H, Value, 1).
+
+record_many(H, Value, N) when is_integer(Value), is_integer(N), N > 0 ->
+    do_record(H, Value, N).
+
+do_record(H, Value, N) ->
+    Index = get_value_index(H, Value),
+    case H#hist.max < Value orelse
+        Index < 0 orelse H#hist.counts_length =< Index of
+        true ->
+            {error, value_out_of_range};
+        false ->
+            storage_record(H, Index, N)
+    end.
+
+reset(H) ->
+    storage_reset(H).
+
+delete(H) ->
+    storage_delete(H).
+
+%% @doc Get the total number of recorded values. This is O(1)
+-spec total_count(#hist{}) -> non_neg_integer().
+total_count(H) ->
+    Counts = storage_get_counts(H),
+    element(?TOTAL_COUNT_INDEX, Counts).
+
+max(H) ->
+    hd(do_get_multi_value(iterator(H), [max])).
+
+min(H) ->
+    hd(do_get_multi_value(iterator(H), [min])).
+
+mean(H) ->
+    do_mean(iterator(H)).
+
+-spec percentile(#hist{}, float()) -> float().
+percentile(H, Q) when Q > 0 andalso Q =< 100 ->
+    hd(do_get_multi_value(iterator(H), [{percentile, Q}])).
+
+stats(H) ->
+    It = iterator(H),
+    [Min, P50, P75, P90, P99, Max] =
+        do_get_multi_value(
+          It,
+          [min,
+           {percentile, 50.0},
+           {percentile, 75.0},
+           {percentile, 90.0},
+           {percentile, 99.0},
+           max]),
+    [{count, do_total_count(It)},
+     {min, Min},
+     {mean, do_mean(It)},
+     {max, Max},
+     {p50, P50},
+     {p75, P75},
+     {p90, P90},
+     {p99, P99}
+    ].
+
+%%
+%% Storage
+%%
+
+storage_new() ->
+    ets:new(?MODULE, [set, private]).
+
+storage_new_concurrent(Name) ->
+    ets:new(Name, [set, public, {write_concurrency, true}]).
+
+storage_record(H, Index, N) ->
+    ets:update_counter(H#hist.table, H#hist.name,
+                       [{?TOTAL_COUNT_INDEX, N},
+                        {Index + ?TOTAL_COUNT_INDEX + 1, N}]),
+    ok.
+
+storage_get_counts(H) ->
+    case ets:lookup(H#hist.table, H#hist.name) of
+        [] ->
+            throw(data_missing_from_ets);
+        [Counts] ->
+            Counts
+    end.
+
+storage_reset(H) ->
+    ets:insert(H#hist.table, create_row(H#hist.name, H#hist.counts_length)),
+    ok.
+
+storage_delete(H) ->
+    ets:delete(H#hist.table),
+    ok.
+
+create_row(Name, Count) ->
+    %% counters come after name and total_count that are stored at the start
+    erlang:make_tuple(?TOTAL_COUNT_INDEX + Count, 0, [{1, Name}]).
+
+%%
+%% Calculations
+%%
+
+round_to_significant_figures(0, _) ->
+    0;
+round_to_significant_figures(V, Prec) ->
+    Factor = math:pow(10.0, Prec - int_ceil(math:log10(abs(V)))),
+    round(V * Factor) / Factor.
+
+calculate_bucket_count(SmallestUntrackableValue, Max, BucketCount) ->
+    case SmallestUntrackableValue < Max of
+        false -> BucketCount;
+        true -> calculate_bucket_count((SmallestUntrackableValue bsl 1),
+                                       Max, BucketCount + 1)
+    end.
+
+get_value_index(H, Value) ->
+    {Bucket, Sub} = get_bucket_indexes(H, Value),
+    get_count_index(H, Bucket, Sub).
+
+get_bucket_indexes(H, Value) ->
+    Ceiling = bit_length((Value bor H#hist.sub_bucket_mask), 0),
+    BucketIndex = Ceiling - H#hist.unit_magnitude - (H#hist.sub_bucket_half_count_magnitude + 1),
+
+    SubBucketIndex = Value bsr (BucketIndex + H#hist.unit_magnitude),
+    {BucketIndex, SubBucketIndex}.
+
+get_bucket_indexes_from_index(H, Index) when Index < H#hist.sub_bucket_half_count ->
+    {0, Index};
+get_bucket_indexes_from_index(H, Index) ->
+    %%Magn = H#hist.sub_bucket_half_count_magnitude,
+    BucketIndex = (Index bsr H#hist.sub_bucket_half_count_magnitude) - 1,
+    SubBucketIndex = (Index + H#hist.sub_bucket_half_count)
+        - ((BucketIndex + 1) bsl H#hist.sub_bucket_half_count_magnitude),
+    {BucketIndex, SubBucketIndex}.
+
+bit_length(Value, N) when Value >= 32768 ->
+    bit_length((Value bsr 16), N + 16);
+bit_length(Value, N) ->
+    {Value2, N2} = case Value >= 128 of
+                       true -> {(Value bsr 8), N + 8};
+                       false -> {Value, N}
+                   end,
+
+    {Value3, N3} = case Value2 >= 8 of
+                       true -> {(Value2 bsr 4), N2 + 4};
+                       false -> {Value2, N2}
+                   end,
+
+    {Value4, N4} = case Value3 >= 2 of
+                       true -> {(Value3 bsr 2), N3 + 2};
+                       false -> {Value3, N3}
+                   end,
+
+    case Value4 =:= 1 of
+        true -> N4 + 1;
+        false -> N4
+    end.
+
+get_count_index(H, BucketIndex, SubBucketIndex) ->
+    BucketBaseIndex =
+        (BucketIndex + 1) bsl H#hist.sub_bucket_half_count_magnitude,
+    OffsetInBucket = SubBucketIndex - H#hist.sub_bucket_half_count,
+    BucketBaseIndex + OffsetInBucket.
+
+value_from_index(H, BucketIndex, SubBucketIndex) ->
+    SubBucketIndex bsl (BucketIndex + H#hist.unit_magnitude).
+
+highest_equivalent_value(H, BucketIndex, SubBucketIndex) ->
+    next_non_equivalent_value(H, BucketIndex, SubBucketIndex) - 1.
+
+lowest_equivalent_value(H, Value) ->
+    {BucketIndex, SubBucketIndex} = get_bucket_indexes(H, Value),
+    lowest_equivalent_value(H, BucketIndex, SubBucketIndex).
+
+lowest_equivalent_value(H, BucketIndex, SubBucketIndex) ->
+    value_from_index(H, BucketIndex, SubBucketIndex).
+
+next_non_equivalent_value(H, BucketIndex, SubBucketIndex) ->
+    lowest_equivalent_value(H, BucketIndex, SubBucketIndex)
+        + size_of_equivalent_value_range(H, BucketIndex, SubBucketIndex).
+
+median_equivalent_value(H, BucketIndex, SubBucketIndex) ->
+    lowest_equivalent_value(H, BucketIndex, SubBucketIndex)
+        + (size_of_equivalent_value_range(H, BucketIndex, SubBucketIndex) bsr 1).
+
+size_of_equivalent_value_range(H, BucketIndex, SubBucketIndex) ->
+    AdjustedBucketIndex =
+        case SubBucketIndex >= H#hist.sub_bucket_count of
+            true -> BucketIndex + 1;
+            false -> BucketIndex
+        end,
+    1 bsl (H#hist.unit_magnitude + AdjustedBucketIndex).
+
+%%
+%% Iteration
+%%
+
+-record(it,
+        {h :: #hist{},
+         total_count,
+         counts
+        }).
+
+iterator(H) ->
+    Counts = storage_get_counts(H),
+    #it{h = H,
+        counts = Counts,
+        total_count = element(?TOTAL_COUNT_INDEX, Counts)}.
+
+do_total_count(It) ->
+    It#it.total_count.
+
+do_mean(It) ->
+    case It#it.total_count of
+        0 -> 0;
+        TotalCount ->
+            TotalSum = do_mean_loop(It, 0, 0, 0),
+            Mean = TotalSum / TotalCount,
+
+            %% the NIF does this rounding on the value returned from c code
+            round_to_significant_figures(Mean, It#it.h#hist.precision)
+    end.
+
+do_mean_loop(It, Index, CountToIndex, Total0) ->
+    case CountToIndex >= It#it.total_count of
+        true -> Total0;
+        false ->
+            CountAtIndex = count_at_index(It, Index),
+            Total =
+                case CountAtIndex of
+                    0 -> Total0;
+                    N ->
+                        {BucketIndex, SubBucketIndex} =
+                            get_bucket_indexes_from_index(It#it.h, Index),
+                        Total0 + N * median_equivalent_value(
+                                       It#it.h,
+                                       BucketIndex,
+                                       SubBucketIndex)
+                end,
+            do_mean_loop(It, Index + 1, CountToIndex + CountAtIndex, Total)
+    end.
+
+do_get_multi_value(#it{total_count = 0}, QList) ->
+    [0 || _ <- QList];
+do_get_multi_value(It, QList) ->
+    PreparedQList =
+        [case Item of
+             max ->
+                 {max, It#it.total_count};
+             min ->
+                 {min, 1};
+             {percentile, Q} ->
+                 CountAtPercentile = round(Q / 100 * It#it.total_count),
+                 {percentile, CountAtPercentile}
+         end
+         || Item <- QList],
+    CountAtIndex = count_at_index(It, 0),
+    do_multi_loop(It, 0, CountAtIndex, PreparedQList, []).
+
+do_multi_loop(It, Index, CountToIndex, [{Tag, CountAtPercentile}|Multi], Res) ->
+    do_multi_loop(It, Index, CountToIndex, Tag, CountAtPercentile, Multi, Res);
+do_multi_loop(_, _, _, [], Res) ->
+    lists:reverse(Res).
+
+do_multi_loop(It, Index, CountToIndex, Tag, CountAtPercentile, Multi, Res) ->
+    case CountToIndex >= CountAtPercentile of
+        true ->
+            do_multi_loop(It, Index, CountToIndex, Multi,
+                          [get_value_from_index(It#it.h, Tag, Index)|Res]);
+        false ->
+            NextIndex = Index + 1,
+            CountAtNextIndex = count_at_index(It, NextIndex),
+            CountToNextIndex = CountToIndex + CountAtNextIndex,
+            do_multi_loop(It, NextIndex, CountToNextIndex, Tag, CountAtPercentile, Multi, Res)
+    end.
+
+get_value_from_index(H, max, MaxIndex) ->
+    {MaxBucketIndex, MaxSubBucketIndex} =
+        get_bucket_indexes_from_index(H, MaxIndex),
+    %% The NIF uses an old version of the c code which calls lowest.
+    %% In newer version of HdrHistogram_c hdr_max was refactorred and
+    %% besides other changes it uses highest.
+
+    %%highest_equivalent_value(It#it.h, MaxValue).
+    lowest_equivalent_value(H, MaxBucketIndex, MaxSubBucketIndex);
+get_value_from_index(H, min, MinIndex) ->
+    {MinBucketIndex, MinSubBucketIndex} =
+        get_bucket_indexes_from_index(H, MinIndex),
+    lowest_equivalent_value(H, MinBucketIndex, MinSubBucketIndex);
+get_value_from_index(H, percentile, Index) ->
+    {BucketIndex, SubBucketIndex} =
+        get_bucket_indexes_from_index(H, Index),
+    V = highest_equivalent_value(H, BucketIndex, SubBucketIndex),
+    %% the NIF does this rounding on the value returned from c code
+    round_to_significant_figures(V, H#hist.precision).
+
+count_at_index(It, Index) ->
+    %% 1 is the name
+    %% 2 is the total_count
+    %% the real count buckets start at 3
+    %% Index is zero based
+    element(Index + ?TOTAL_COUNT_INDEX + 1, It#it.counts).
+
+%% ceil/1 and floor/1 were introduced in OTP 20
+-ifdef(ceil_floor).
+
+int_ceil(F) ->
+    erlang:ceil(F).
+
+int_floor(F) ->
+    erlang:floor(F).
+
+-else.
+
+int_ceil(F) ->
+    R = round(F),
+    if R < F -> R + 1;
+       true -> R
+    end.
+
+int_floor(F) ->
+    R = round(F),
+    if R > F -> R - 1;
+       true -> R
+    end.
+
+-endif.

--- a/apps/xprof_core/src/xprof_core_lib.erl
+++ b/apps/xprof_core/src/xprof_core_lib.erl
@@ -7,6 +7,9 @@
          set_mode/1,
          get_mode/0,
          get_mode_cb/0,
+         set_event_handler/1,
+         unset_event_handler/0,
+         notify_event_handler/1,
          prefix/2,
          prefix_rest/2,
          err/1, err/2, err/3,
@@ -52,6 +55,24 @@ get_mode_cb() ->
     case get_mode() of
         erlang -> xprof_core_erlang_syntax;
         elixir -> xprof_core_elixir_syntax
+    end.
+
+set_event_handler(EventHandler) ->
+    application:set_env(xprof_core, event_handler, EventHandler).
+
+unset_event_handler() ->
+    application:unset_env(xprof_core, event_handler).
+
+notify_event_handler(Msg) ->
+    case application:get_env(xprof_core, event_handler) of
+	undefined ->
+	    ok;
+	{ok, Pid} ->
+	    try Pid ! Msg
+	    catch _:_ ->
+		    %% ignore crash
+		    {error, no_event_handler}
+	    end
     end.
 
 -spec detect_mode() -> xprof_core:mode().

--- a/apps/xprof_core/src/xprof_core_trace_handler.erl
+++ b/apps/xprof_core/src/xprof_core_trace_handler.erl
@@ -219,6 +219,7 @@ maybe_make_snapshot(State = #state{name=Name, last_ts=LastTS,
         DiffMicro when DiffMicro >= ?ONE_SEC ->
             NewState = save_snapshot(NowTS, State),
             remove_outdated_snapshots(Name, xprof_core_lib:now2epoch(NowTS)-WindSize),
+	    xprof_core_lib:notify_event_handler({snapshot, NowTS}),
             {calc_next_timeout(DiffMicro), NewState#state{last_ts = NowTS}};
         DiffMicro ->
             {calc_next_timeout(DiffMicro), State}
@@ -226,7 +227,7 @@ maybe_make_snapshot(State = #state{name=Name, last_ts=LastTS,
 
 calc_next_timeout(DiffMicro) ->
     DiffMilli = DiffMicro div 1000,
-    1000 - DiffMilli rem 1000.
+    1000 - (DiffMilli rem 1000).
 
 save_snapshot(NowTS, State = #state{name = Name, cb_mod = CmdCB, cb_state = CBState}) ->
     Epoch = xprof_core_lib:now2epoch(NowTS),

--- a/apps/xprof_core/src/xprof_core_tracer.erl
+++ b/apps/xprof_core/src/xprof_core_tracer.erl
@@ -245,8 +245,9 @@ put_pid(MFA, Pid) ->
 erase_pid(MFA) ->
     erase({handler, MFA}).
 
+%% FIXME OTP 19+
 %% the rand module was introduced in OTP 18.0
-%% and random module deprecated in OTP 19.0
+%% and random module was deprecated in OTP 19.0
 -ifdef(rand_module).
 random_uniform() ->
     rand:uniform().

--- a/apps/xprof_core/test/xprof_core_hist_SUITE.erl
+++ b/apps/xprof_core/test/xprof_core_hist_SUITE.erl
@@ -1,0 +1,212 @@
+-module(xprof_core_hist_SUITE).
+
+-export([all/0]).
+-export([groups/0]).
+-export([suite/0]).
+-export([init_per_suite/1]).
+-export([end_per_suite/1]).
+-export([group/1]).
+-export([init_per_group/2]).
+-export([end_per_group/2]).
+-export([init_per_testcase/2]).
+-export([end_per_testcase/2]).
+
+-define(root,?config(data_dir,Config)).
+
+-export([t_hdr_create/1]).
+-export([t_hdr_total_count/1]).
+-export([t_hdr_max_value/1]).
+-export([t_hdr_min_value/1]).
+-export([t_hdr_mean_value/1]).
+-export([t_hdr_percentiles/1]).
+-export([t_hdr_reset/1]).
+-export([t_hdr_close/1]).
+-export([t_issue_004/1]).
+-export([t_issue_013/1]).
+-export([t_use_after_close/1]).
+
+-export([load_histograms/0]).
+
+-include_lib("common_test/include/ct.hrl").
+
+-define(BADARG(Expr), (fun() ->
+                               case (catch Expr) of
+                                   {'EXIT', {badarg, _}} -> ok;
+                                   __Other__ -> ct:fail([{line, ?LINE},
+                                                         {expected, badarg},
+                                                         {actual, __Other__}])
+                               end
+                       end)()).
+
+all() ->
+    [
+     {group, hdr}
+    , {group, regression}
+    ].
+
+groups() ->
+    [{hdr, [], [
+        t_hdr_create
+      , t_hdr_total_count
+      , t_hdr_max_value
+      , t_hdr_min_value
+      , t_hdr_mean_value
+      , t_hdr_percentiles
+      , t_hdr_reset
+      , t_hdr_close
+    ]},
+     %% Counter examples / regression tests for bugs
+    {regression, [], [
+        t_issue_004,
+        t_issue_013,
+        t_use_after_close
+    ]}].
+
+suite() ->
+    [{ct_hooks, [cth_surefire]}, {timetrap, 2000}].
+
+init_per_suite(Config) ->
+    Config.
+
+end_per_suite(Config) ->
+    Config.
+
+group(_GroupName) ->
+    [].
+
+init_per_group(_GroupName, Config) ->
+    Raw = load_histograms(),
+    [{raw,Raw}|Config].
+
+end_per_group(_GroupName, Config) ->
+    Config.
+
+init_per_testcase(_TestCase, Config) ->
+    Config.
+
+end_per_testcase(_TestCase, Config) ->
+    Config.
+
+t_hdr_create(_Config) ->
+    {ok,R} = xprof_core_hist:open(36000000, 4),
+    xprof_core_hist:close(R),
+    ok.
+
+t_hdr_total_count(Config) ->
+    Raw = ?config(raw,Config),
+    10001 = xprof_core_hist:total_count(Raw),
+    ok.
+
+t_hdr_max_value(Config) ->
+    Raw = ?config(raw,Config),
+    RawMax = xprof_core_hist:max(Raw),
+    xprof_core_hist:same(Raw,100000000,RawMax),
+    ok.
+
+t_hdr_min_value(Config) ->
+    Raw = ?config(raw,Config),
+    1000 = xprof_core_hist:min(Raw),
+    ok.
+
+t_hdr_mean_value(Config) ->
+    Raw = ?config(raw,Config),
+    11000.0 = xprof_core_hist:mean(Raw),
+    ok.
+
+t_hdr_percentiles(Config) ->
+    Raw = ?config(raw,Config),
+    cmp(1.0e3 , xprof_core_hist:percentile(Raw, 30.0), 0.001),
+    cmp(1.0e3 , xprof_core_hist:percentile(Raw, 99.0), 0.001),
+    cmp(1.0e3 , xprof_core_hist:percentile(Raw, 99.99), 0.001),
+    cmp(1.0e8 , xprof_core_hist:percentile(Raw, 99.999), 0.001),
+    cmp(1.0e8 , xprof_core_hist:percentile(Raw, 100.0), 0.001),
+    ok.
+
+t_hdr_reset(Config) ->
+    Raw = ?config(raw,Config),
+    xprof_core_hist:reset(Raw),
+    0 = xprof_core_hist:total_count(Raw),
+    %% FIXME why is this an integer???
+    %%0.0 = xprof_core_hist:percentile(Raw, 99.0),
+    0 = xprof_core_hist:percentile(Raw, 99.0),
+    ok.
+
+t_hdr_close(Config) ->
+    Raw = ?config(raw,Config),
+    xprof_core_hist:close(Raw),
+    %% double close is harmless
+    ok.
+
+t_issue_004(_Config) ->
+    {ok,R} = xprof_core_hist:open(10,1),
+    [ begin
+        ok = xprof_core_hist:record(R, X)
+    end || X <- lists:seq(0,10) ],
+    {error, value_out_of_range} = xprof_core_hist:record(R, -1),
+    {error, value_out_of_range} = xprof_core_hist:record(R, 11),
+    ok = xprof_core_hist:close(R).
+
+t_issue_013(_Config) ->
+    {ok,R} = xprof_core_hist:open(10,1),
+    [ begin
+      ok = xprof_core_hist:record_many(R, X, 10)
+    end || X <- lists:seq(0,10) ],
+    {error, value_out_of_range} = xprof_core_hist:record(R, -1),
+    {error, value_out_of_range} = xprof_core_hist:record(R, 11),
+    ok = xprof_core_hist:close(R).
+
+t_use_after_close(_Config) ->
+    {ok, Closed} = xprof_core_hist:open(10, 1),
+    ok = xprof_core_hist:close(Closed),
+
+    ?BADARG(xprof_core_hist:total_count(Closed)),
+
+    ?BADARG(xprof_core_hist:record(Closed, 1)),
+    ?BADARG(xprof_core_hist:record_many(Closed, 1, 5)),
+
+    ?BADARG(xprof_core_hist:min(Closed)),
+    ?BADARG(xprof_core_hist:max(Closed)),
+    ?BADARG(xprof_core_hist:mean(Closed)),
+
+    ?BADARG(xprof_core_hist:percentile(Closed, 50.0)),
+
+    ?BADARG(xprof_core_hist:same(Closed, 5, 5)),
+
+    ?BADARG(xprof_core_hist:reset(Closed)),
+    ?BADARG(xprof_core_hist:close(Closed)),
+
+    ok.
+
+load_histograms() ->
+    %% init_per_group is run in a separate process which terminates
+    %% before the test cases are run
+    %% so spawn a separate long-lived process that owns the ets tables
+    InitGroupProc = self(),
+    proc_lib:spawn(
+      fun() ->
+              Res = (catch xprof_core_hist:open(raw_table, 3600 * 1000 * 1000, 3)),
+              InitGroupProc ! Res,
+              receive _ -> stop end
+      end),
+    receive
+        {ok, Raw} -> ok;
+        Error -> error(Error),
+                 Raw = error
+    end,
+    load(10000, Raw),
+    ok = xprof_core_hist:record(Raw, 100000000),
+    Raw.
+
+load(0, Raw) ->
+    Raw;
+load(N, Raw) ->
+    ok = xprof_core_hist:record(Raw, 1000),
+    load(N-1, Raw).
+
+cmp(L1,L2,D) ->
+    case erlang:abs(L1-L2) < D of
+	false -> throw({not_same, L1, L2, D,
+                        element(2, erlang:process_info(
+                                     self(), current_stacktrace))});
+	true -> true
+    end.

--- a/rebar.config
+++ b/rebar.config
@@ -27,10 +27,3 @@
 
 {coveralls_coverdata, [ "_build/test/cover/eunit.coverdata", "_build/test/cover/ct.coverdata" ]}.
 {coveralls_service_name, "travis-ci"}.
-
-%% customized_hdr_histogram defines rebar_hex plugin
-%% but that is only needed for package publishing
-%% (and we don't want to publish hdr_histogram packages)
-{overrides,
- [{override, customized_hdr_histogram, [{plugins, []}]}
- ]}.

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,10 +1,8 @@
 {"1.1.0",
 [{<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.0.0">>},0},
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.0.1">>},1},
- {<<"customized_hdr_histogram">>,
-  {pkg,<<"customized_hdr_histogram">>,<<"0.3.2">>},
-  0},
  {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
+ {<<"hdr_histogram">>,{pkg,<<"hdr_histogram">>,<<"0.3.2">>},0},
  {<<"jsone">>,{pkg,<<"jsone">>,<<"1.4.7">>},0},
  {<<"lager">>,{pkg,<<"lager">>,<<"3.2.4">>},0},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"1.4.0">>},1}]}.
@@ -12,8 +10,8 @@
 {pkg_hash,[
  {<<"cowboy">>, <<"A3B680BCC1156C6FBCB398CC56ADC35177037012D7DC28D8F7E7926D6C243561">>},
  {<<"cowlib">>, <<"4DFFFB1DB296EAB9F2E8B95EE3017007F674BC920CE30AEB5A53BBDA82FC38C0">>},
- {<<"customized_hdr_histogram">>, <<"14DDAE316FB694455FCC20CBD1AD5F057E421132E562AFB93BD81EDA44BD937D">>},
  {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
+ {<<"hdr_histogram">>, <<"11F4DB284E254614A2164EEF0BFCAB70F9F053481DB428D65E0ACB4B71DB2E4F">>},
  {<<"jsone">>, <<"A970C23D9700AE7842B526C57677E6E3F10894B429524696EAD547E9302391C0">>},
  {<<"lager">>, <<"A6DEB74DAE7927F46BD13255268308EF03EB206EC784A94EAF7C1C0F3B811615">>},
  {<<"ranch">>, <<"10272F95DA79340FA7E8774BA7930B901713D272905D0012B06CA6D994F8826B">>}]}


### PR DESCRIPTION
- Switch back to upstream hdr_histogram 0.3.2
  It already contains some fixes missing from our fork
- Add native Erlang implementation of hdr_histogram 
- OS env var to choose between NIF or native Erlang implementation
  As the Erlang version is somewhat slower (not measured precisely) the NIF is the default 


fixes #86 