### PR TITLE
Restructure ifdefs

### DIFF
--- a/apps/xprof_core/rebar.config
+++ b/apps/xprof_core/rebar.config
@@ -5,7 +5,6 @@
 
 {erl_opts, [debug_info,
             {parse_transform, lager_transform},
-            {platform_define, "^(R|17|18)", before_OTP_19},
-            {platform_define, "^((1[8|9])|2)", rand_module},
-            {platform_define, "^[^R1]", ceil_floor}
+            {platform_define, "^(R|17)", before_OTP_18},
+            {platform_define, "^[^R1]", ceil_floor} %% from OTP 20
            ]}.

--- a/apps/xprof_core/src/test_module.erl
+++ b/apps/xprof_core/src/test_module.erl
@@ -18,7 +18,7 @@ loop() ->
 expensive_fun(SleepTime) ->
     timer:sleep(SleepTime).
 
--ifdef(rand_module).
+-ifndef(before_OTP_18).
 random_uniform(N) ->
     rand:uniform(N).
 -else.

--- a/apps/xprof_core/src/xprof_core_erlang_syntax.erl
+++ b/apps/xprof_core/src/xprof_core_erlang_syntax.erl
@@ -249,10 +249,9 @@ rest_from_tokens([FirstToken|_], OrigQuery) ->
     StartColumn = column(FirstToken) - 1,
     _RestStr = lists:sublist(OrigQuery, StartColumn, length(OrigQuery)).
 
-%% FIXME OTP 19+
-%% erl_anno module and erl_scan:text was introduced in OTP 18.0
+%% erl_anno module and erl_scan:text were introduced in OTP 18.0
+-ifdef(before_OTP_18).
 text(Token) ->
-    %% erl_scan:text(Token).
     proplists:get_value(text, element(2, Token)).
 
 column(Token) ->
@@ -267,6 +266,15 @@ column(Token) ->
                 _ -> undefined
             end
     end.
+
+-else.
+text(Token) ->
+    erl_scan:text(Token).
+
+column(Token) ->
+    erl_scan:column(Token).
+
+-endif.
 
 %% @doc Parse a query string that represents either a module-function-arity
 %% or an xprof-flavoured match-spec fun in Erlang syntax.

--- a/apps/xprof_core/src/xprof_core_hist.erl
+++ b/apps/xprof_core/src/xprof_core_hist.erl
@@ -534,10 +534,7 @@ int_floor(F) ->
 
 -endif.
 
-%% FIXME OTP 19+
-%% Remove this section when we no longer support old Erlang versions
-%% (R16B - 18)
--ifdef(before_OTP_19).
+-ifdef(before_OTP_18).
 
 math_log2(V) ->
     math:log(V)/math:log(2).

--- a/apps/xprof_core/src/xprof_core_tracer.erl
+++ b/apps/xprof_core/src/xprof_core_tracer.erl
@@ -245,10 +245,9 @@ put_pid(MFA, Pid) ->
 erase_pid(MFA) ->
     erase({handler, MFA}).
 
-%% FIXME OTP 19+
 %% the rand module was introduced in OTP 18.0
 %% and random module was deprecated in OTP 19.0
--ifdef(rand_module).
+-ifndef(before_OTP_18).
 random_uniform() ->
     rand:uniform().
 -else.


### PR DESCRIPTION
I was hoping to jump to OTP 19+ support soon (with tracer NIFs etc), but
it looks like XProf will need to support OTP 18 for a while. So let's
use all the new functions (like rand module, math:log2, erl_anno etc) if
they are available, and create a single `before_OTP_18` macro for the
older stuff.