### PR TITLE
Don't use lager

### DIFF
--- a/apps/xprof_core/rebar.config
+++ b/apps/xprof_core/rebar.config
@@ -1,10 +1,8 @@
 {deps,
- [{hdr_histogram, "~> 0.3"},
-  {lager, "~> 3.5"}
+ [{hdr_histogram, "~> 0.3"}
  ]}.
 
 {erl_opts, [debug_info,
-            {parse_transform, lager_transform},
             {platform_define, "^(R|17)", before_OTP_18},
             {platform_define, "^[^R1]", ceil_floor} %% from OTP 20
            ]}.

--- a/apps/xprof_core/src/xprof_core.app.src
+++ b/apps/xprof_core/src/xprof_core.app.src
@@ -7,7 +7,6 @@
    [kernel
    ,stdlib
    ,compiler
-   ,lager
    ,hdr_histogram
    ]}
  ,{env,[]}

--- a/apps/xprof_core/src/xprof_core_cmd_funlatency.erl
+++ b/apps/xprof_core/src/xprof_core_cmd_funlatency.erl
@@ -119,9 +119,10 @@ handle_event({trace_ts, Pid, Tag, MFA, RetOrExc, EndTime},
                 {true, NewRet} ->
                     CallTime = timer:now_diff(EndTime, StartTime),
                     if CallTime > MaxDuration ->
-                            lager:error("Call ~p took ~p ms that is larger than the maximum "
-                                        "that can be stored (~p ms)",
-                                        [MFA, CallTime/1000, MaxDuration div 1000]),
+                            error_logger:warning_msg(
+                              "~p: Call ~p took ~p ms that is larger than the maximum "
+                              "that can be stored (~p ms)",
+                              [?MODULE, MFA, CallTime/1000, MaxDuration div 1000]),
                             ok = xprof_core_hist:hdr_record(Ref, MaxDuration);
                        true ->
                             ok = xprof_core_hist:hdr_record(Ref, CallTime)

--- a/apps/xprof_core/src/xprof_core_records.erl
+++ b/apps/xprof_core/src/xprof_core_records.erl
@@ -72,8 +72,13 @@ record_print_fun() ->
 init([]) ->
     ets:new(?TABLE, [set, protected, named_table, {read_concurrency, true}]),
     Mods = application:get_env(xprof_core, load_records, []),
-    RecNames = lists:flatmap(fun get_and_store_record_defs/1, Mods),
-    lager:info("Loaded records: ~p", [RecNames]),
+    case Mods of
+        [] ->
+            ok;
+        _ ->
+            RecNames = lists:flatmap(fun get_and_store_record_defs/1, Mods),
+            error_logger:info_msg("~p: Loaded records: ~p", [?MODULE, RecNames])
+    end,
     {ok, #state{}}.
 
 handle_call({load_records, Mod}, _From, State) ->

--- a/apps/xprof_core/src/xprof_core_trace_handler.erl
+++ b/apps/xprof_core/src/xprof_core_trace_handler.erl
@@ -68,10 +68,7 @@ data(MFA, FromEpoch) ->
 %% than specified time threshold.
 -spec capture(xprof_core:mfa_id(), non_neg_integer(), non_neg_integer()) ->
                      {ok, non_neg_integer()} | {error, not_found}.
-capture(MFA = {M,F,A}, Threshold, Limit) ->
-    lager:info("Capturing ~p calls to ~w:~w/~w that exceed ~p ms:",
-               [Limit, M, F, A, Threshold]),
-
+capture(MFA, Threshold, Limit) ->
     Name = xprof_core_lib:mfa2atom(MFA),
     try
         gen_server:call(Name, {capture, Threshold, Limit})
@@ -170,8 +167,7 @@ handle_call(capture_stop, _From, State = #state{mfa_spec = MFASpec}) ->
     ets:insert(Name, {capture_spec, Id, Threshold, Count, Limit}),
     {Timeout, NewState2} = maybe_make_snapshot(NewState),
     {reply, ok, NewState2, Timeout};
-handle_call(Request, _From, State) ->
-    lager:warning("Received unknown message: ~p", [Request]),
+handle_call(_Request, _From, State) ->
     {reply, ignored, State}.
 
 handle_cast(_Msg, State) ->

--- a/apps/xprof_core/src/xprof_core_tracer.erl
+++ b/apps/xprof_core/src/xprof_core_tracer.erl
@@ -70,8 +70,7 @@ prepare_and_start_cmd(StartCmd) ->
 
 %% @doc Stops monitoring specified function calls.
 -spec demonitor(xprof_core:mfa_id()) -> ok.
-demonitor({Mod, Fun, Arity} = MFA) ->
-    lager:info("Stopping monitoring ~w:~w/~w",[Mod,Fun,Arity]),
+demonitor(MFA) ->
     gen_server:call(?MODULE, {demonitor, MFA}).
 
 %% @doc Returns list of monitored functions
@@ -83,7 +82,6 @@ all_monitored() ->
 %% processes or processes that are spawned by specified spawner pid.
 -spec trace(pid() | pause| resume | all | {spawner, pid()}) -> ok.
 trace(PidOrSpec) ->
-    lager:info("Tracing ~p", [PidOrSpec]),
     gen_server:call(?MODULE, {trace, PidOrSpec}).
 
 %% @doc Returns current tracing state.

--- a/apps/xprof_gui/rebar.config
+++ b/apps/xprof_gui/rebar.config
@@ -1,8 +1,6 @@
 {deps,
  [{cowboy, "~> 2.5"},
-  {lager, "~> 3.5"},
   {jsone, "~> 1.5"}
  ]}.
 
-{erl_opts, [debug_info,
-            {parse_transform, lager_transform}]}.
+{erl_opts, [debug_info]}.

--- a/apps/xprof_gui/src/xprof_gui.app.src
+++ b/apps/xprof_gui/src/xprof_gui.app.src
@@ -7,7 +7,6 @@
    [kernel
    ,stdlib
    ,cowboy
-   ,lager
    ,jsone
    ]}
  ,{env,[]}

--- a/apps/xprof_gui/src/xprof_gui_favourites.erl
+++ b/apps/xprof_gui/src/xprof_gui_favourites.erl
@@ -59,8 +59,7 @@ handle_call({add, XprofQuery}, _From, State = #state{queries = Queries}) ->
 
 handle_call(get_all, _From, State = #state{queries = Queries}) ->
     {reply, Queries, State};
-handle_call(Request, _From, State) ->
-    lager:warning("Received unknown message: ~p", [Request]),
+handle_call(_Request, _From, State) ->
     {reply, ignored, State}.
 
 handle_cast(_Msg, State) ->

--- a/apps/xprof_gui/src/xprof_gui_favourites_config.erl
+++ b/apps/xprof_gui/src/xprof_gui_favourites_config.erl
@@ -10,7 +10,9 @@ load_queries() ->
     case file:consult(File) of
         {ok, Queries} -> {ok, Queries};
         {error, Reason} ->
-            lager:warning("Couldn't open file: ~p. Using empty favourites list.", [Reason]),
+            error_logger:warning_msg(
+              "~p: Couldn't open file: ~p. Using empty favourites list.",
+              [?MODULE, Reason]),
             {ok, []}
     end.
 

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,18 +1,14 @@
 {"1.1.0",
 [{<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.6.3">>},0},
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.7.3">>},1},
- {<<"goldrush">>,{pkg,<<"goldrush">>,<<"0.1.9">>},1},
  {<<"hdr_histogram">>,{pkg,<<"hdr_histogram">>,<<"0.3.2">>},0},
  {<<"jsone">>,{pkg,<<"jsone">>,<<"1.5.0">>},0},
- {<<"lager">>,{pkg,<<"lager">>,<<"3.5.0">>},0},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"1.7.1">>},1}]}.
 [
 {pkg_hash,[
  {<<"cowboy">>, <<"99AA50E94E685557CAD82E704457336A453D4ABCB77839AD22DBE71F311FCC06">>},
  {<<"cowlib">>, <<"A7FFCD0917E6D50B4D5FB28E9E2085A0CEB3C97DEA310505F7460FF5ED764CE9">>},
- {<<"goldrush">>, <<"F06E5D5F1277DA5C413E84D5A2924174182FB108DABB39D5EC548B27424CD106">>},
  {<<"hdr_histogram">>, <<"11F4DB284E254614A2164EEF0BFCAB70F9F053481DB428D65E0ACB4B71DB2E4F">>},
  {<<"jsone">>, <<"410F5208BCAE541BF941B3F2756E5BB5A4C8694D7FFD6B34B909AE88262629C0">>},
- {<<"lager">>, <<"C7D35985D784CCE9F8FA4056023CE873252B68BC31A81C63E4286857713DD6CE">>},
  {<<"ranch">>, <<"6B1FAB51B49196860B733A49C07604465A47BDB78AA10C1C16A3D199F7F8C881">>}]}
 ].


### PR DESCRIPTION
XProf has little need for logging. The remaining log entries go via the
legacy error_logger API, which are handled by the new logger from OTP 21.

closes #69