### PR TITLE
Lock hdr_histogram to master for OTP 23 compatibility

### DIFF
--- a/apps/xprof_core/rebar.config
+++ b/apps/xprof_core/rebar.config
@@ -1,5 +1,5 @@
 {deps,
- [{hdr_histogram, "~> 0.3"}
+ [{hdr_histogram, {git, "https://github.com/HdrHistogram/hdr_histogram_erl.git", {branch, "master"}}}
  ]}.
 
 {erl_opts, [debug_info,

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,14 +1,16 @@
 {"1.1.0",
 [{<<"cowboy">>,{pkg,<<"cowboy">>,<<"2.6.3">>},0},
  {<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.7.3">>},1},
- {<<"hdr_histogram">>,{pkg,<<"hdr_histogram">>,<<"0.3.2">>},0},
+ {<<"hdr_histogram">>,
+  {git,"https://github.com/HdrHistogram/hdr_histogram_erl.git",
+       {ref,"075798518aabd73a0037007989cde8bd6923b4d9"}},
+  0},
  {<<"jsone">>,{pkg,<<"jsone">>,<<"1.5.0">>},0},
  {<<"ranch">>,{pkg,<<"ranch">>,<<"1.7.1">>},1}]}.
 [
 {pkg_hash,[
  {<<"cowboy">>, <<"99AA50E94E685557CAD82E704457336A453D4ABCB77839AD22DBE71F311FCC06">>},
  {<<"cowlib">>, <<"A7FFCD0917E6D50B4D5FB28E9E2085A0CEB3C97DEA310505F7460FF5ED764CE9">>},
- {<<"hdr_histogram">>, <<"11F4DB284E254614A2164EEF0BFCAB70F9F053481DB428D65E0ACB4B71DB2E4F">>},
  {<<"jsone">>, <<"410F5208BCAE541BF941B3F2756E5BB5A4C8694D7FFD6B34B909AE88262629C0">>},
  {<<"ranch">>, <<"6B1FAB51B49196860B733A49C07604465A47BDB78AA10C1C16A3D199F7F8C881">>}]}
 ].


### PR DESCRIPTION
I just noticed xprof only compiles with hdr_histogram locked to master on OTP 23 (due to the erl_interface thing).
Feel free to go about this in your preferred way!